### PR TITLE
New release for eo-0.58.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.57.3</eo.version>
+    <eo.version>0.58.0</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:22

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:56

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:53

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:47

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:82

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.3
++version 0.58.0
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:94

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:40

--- a/objects/org/eolang/structs/range-of-ints.eo
+++ b/objects/org/eolang/structs/range-of-ints.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:65

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:26

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:44

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:23

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:28

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:49

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:16

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58
@@ -95,3 +95,27 @@
       sprintf
         "%d"
         * 42.as-i64.as-number
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> formats-numbered-substitution
+    eq. > @
+      "Hello, Jeff! Bye, Jeff!"
+      sprintf
+        "Hello, %s! Bye, %1$s!"
+        * "Jeff"
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> formats-numbered-substitution-with-multiple-args
+    eq. > @
+      "This is the first; This is the first as well; The second; and the 3"
+      sprintf
+        "This is the %s; This is the %1$s as well; The %s; and the %d"
+        * "first" "second" 3
+
+  # This unit test is supposed to check the functionality of the corresponding object.
+  [] +> formats-with-ordered-numbered-substitutions
+    eq. > @
+      "first second second is after first"
+      sprintf
+        "%s %s %2$s is after %1$s"
+        * "first" "second"

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.57.3
++rt jvm org.eolang:eo-runtime:0.58.0
 +rt node eo2js-runtime:0.0.0
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:24

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.57.3
++version 0.58.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.58.0` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.