### PR TITLE
New release for eo-0.58.6

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.58.3</eo.version>
+    <eo.version>0.58.6</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/org/eolang/bytes.eo
+++ b/objects/org/eolang/bytes.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:22

--- a/objects/org/eolang/cti.eo
+++ b/objects/org/eolang/cti.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/dataized.eo
+++ b/objects/org/eolang/dataized.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/error.eo
+++ b/objects/org/eolang/error.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/false.eo
+++ b/objects/org/eolang/false.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/fs/dir.eo
+++ b/objects/org/eolang/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/fs/file.eo
+++ b/objects/org/eolang/fs/file.eo
@@ -6,9 +6,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/fs/path.eo
+++ b/objects/org/eolang/fs/path.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:56

--- a/objects/org/eolang/fs/tmpdir.eo
+++ b/objects/org/eolang/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.fs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/go.eo
+++ b/objects/org/eolang/go.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:53

--- a/objects/org/eolang/i16.eo
+++ b/objects/org/eolang/i16.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/i32.eo
+++ b/objects/org/eolang/i32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/i64.eo
+++ b/objects/org/eolang/i64.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/io/bytes-as-input.eo
+++ b/objects/org/eolang/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:47

--- a/objects/org/eolang/io/console.eo
+++ b/objects/org/eolang/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:82

--- a/objects/org/eolang/io/copied.eo
+++ b/objects/org/eolang/io/copied.eo
@@ -1,0 +1,98 @@
++alias org.eolang.io.bytes-as-input
++alias org.eolang.io.dead-input
++alias org.eolang.io.dead-output
++alias org.eolang.io.input-length
++alias org.eolang.io.malloc-as-output
++alias org.eolang.io.tee-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package org.eolang.io
++version 0.58.6
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Copies all bytes from the provided `input` to the provided `output`
+# and returns the total number of bytes copied.
+#
+# Example usage:
+# ```
+# copied > total-bytes
+#   bytes-as-input 01-02-03-04-05
+#   malloc-as-output memory
+# ```
+# After dataization, `total-bytes` equals 5, and all bytes have been
+# copied from input to output.
+[input output] > copied
+  input-length > @
+    tee-input
+      input
+      output
+
+  # Tests that copied copies all bytes from input to output and returns the length.
+  [] +> tests-copies-all-bytes-and-returns-length
+    eq. > @
+      malloc.of
+        5
+        [m]
+          seq > @
+            *
+              copied
+                bytes-as-input 01-02-03-04-05
+                malloc-as-output m
+              m
+      01-02-03-04-05
+
+  # Tests that copied returns the correct byte count.
+  [] +> tests-returns-correct-byte-count
+    eq. > @
+      malloc.of
+        10
+        [m]
+          copied > @
+            bytes-as-input 01-02-03-04-05-06-07-08-09-10
+            malloc-as-output m
+      10
+
+  # Tests that copied handles empty input correctly.
+  [] +> tests-handles-empty-input
+    eq. > @
+      malloc.of
+        0
+        [m]
+          seq > @
+            *
+              copied
+                bytes-as-input --
+                malloc-as-output m
+              m
+      --
+
+  # Tests that copied returns 0 for empty input.
+  [] +> tests-returns-zero-for-empty-input
+    eq. > @
+      malloc.of
+        0
+        [m]
+          copied > @
+            bytes-as-input --
+            malloc-as-output m
+      0
+
+  # Tests that copied works with larger data.
+  [] +> tests-handles-large-data
+    eq. > @
+      20
+      malloc.of
+        20
+        [m]
+          copied > @
+            bytes-as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+            malloc-as-output m
+
+  # Tests that copied handles dead input gracefully.
+  [] +> tests-handles-dead-input
+    eq. > @
+      copied
+        dead-input
+        dead-output
+      0

--- a/objects/org/eolang/io/dead-input.eo
+++ b/objects/org/eolang/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/dead-output.eo
+++ b/objects/org/eolang/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/input-length.eo
+++ b/objects/org/eolang/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/malloc-as-output.eo
+++ b/objects/org/eolang/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/io/stdin.eo
+++ b/objects/org/eolang/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/io/stdout.eo
+++ b/objects/org/eolang/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/io/tee-input.eo
+++ b/objects/org/eolang/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.io
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:43

--- a/objects/org/eolang/malloc.eo
+++ b/objects/org/eolang/malloc.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/angle.eo
+++ b/objects/org/eolang/math/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/math/e.eo
+++ b/objects/org/eolang/math/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.3
++version 0.58.6
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/org/eolang/math/integral.eo
+++ b/objects/org/eolang/math/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/numbers.eo
+++ b/objects/org/eolang/math/numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/math/pi.eo
+++ b/objects/org/eolang/math/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/math/random.eo
+++ b/objects/org/eolang/math/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/math/real.eo
+++ b/objects/org/eolang/math/real.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.math
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/nan.eo
+++ b/objects/org/eolang/nan.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18

--- a/objects/org/eolang/negative-infinity.eo
+++ b/objects/org/eolang/negative-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/net/socket.eo
+++ b/objects/org/eolang/net/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.net
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/number.eo
+++ b/objects/org/eolang/number.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:20

--- a/objects/org/eolang/positive-infinity.eo
+++ b/objects/org/eolang/positive-infinity.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:19

--- a/objects/org/eolang/runtime.eo
+++ b/objects/org/eolang/runtime.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation

--- a/objects/org/eolang/seq.eo
+++ b/objects/org/eolang/seq.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/string.eo
+++ b/objects/org/eolang/string.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:94
@@ -16,9 +16,9 @@
 #
 # Usage examples:
 # ```
-# string "Hello, 世界!"  # Unicode string creation
-# "text".length         # Character count (not bytes)
-# "text".slice 0 2      # Character-based slicing
+# string "Hello, \u4e16\u754c!"  # Unicode string creation
+# "text".length                  # Character count (not bytes)
+# "text".slice 0 2               # Character-based slicing
 # ```
 [as-bytes] > string
   as-bytes > @

--- a/objects/org/eolang/structs/bytes-as-array.eo
+++ b/objects/org/eolang/structs/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/hash-code-of.eo
+++ b/objects/org/eolang/structs/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/structs/list.eo
+++ b/objects/org/eolang/structs/list.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:18
@@ -261,6 +261,42 @@
               accum
     index > idx!
     origin.length.minus idx > start!
+
+  # Get a sublist from `start` index to `end` index (not inclusive).
+  [start end] > slice
+    if. > @
+      (number s).gte e
+      list *
+      list
+        reducedi
+          *
+          [accum item idx] >>
+            if. > @
+              and.
+                idx.gte s
+                idx.lt e
+              accum.with item
+              accum
+    if. > s!
+      start.gte 0
+      if.
+        start.gte origin.length
+        origin.length
+        start
+      if.
+        origin.length.neg.lte start
+        start.plus origin.length
+        0
+    if. > e!
+      end.gte 0
+      if.
+        end.gte origin.length
+        origin.length
+        end
+      if.
+        origin.length.neg.lte end
+        end.plus origin.length
+        0
 
   # Tests that a list with elements is not empty.
   [] +> tests-list-should-not-be-empty
@@ -768,3 +804,113 @@
           * 1 2 3 4 5
         10
       * 1 2 3 4 5
+
+  # Tests that slice works correctly.
+  [] +> tests-simple-slice
+    eq. > @
+      slice.
+        list
+          * 1 2 3 4 5
+        1
+        5
+      * 2 3 4 5
+
+  # Tests that slice with negative start index works correctly.
+  [] +> tests-slice-with-negative-start
+    eq. > @
+      slice.
+        list
+          * 8 76 -3 0 3 8 -12
+        -4
+        6
+      * 0 3 8
+
+  # Tests that slice with negative end index works correctly.
+  [] +> tests-slice-with-negative-end
+    eq. > @
+      slice.
+        list
+          * "a" 2 3.0 "xyz" 82.42 7
+        0
+        -1
+      * "a" 2 3.0 "xyz" 82.42
+
+  # Tests that slice with both negative start and end indices works correctly.
+  [] +> tests-slice-with-negative-start-and-end
+    eq. > @
+      slice.
+        list
+          * 8 23 0 0 "foo"
+        -4
+        -1
+      * 23 0 0
+
+  # Tests that slice with end greater than length works correctly.
+  [] +> tests-slice-with-end-gt-length
+    eq. > @
+      slice.
+        list
+          * "foo" "bar" "buzz"
+        1
+        10
+      * "bar" "buzz"
+
+  # Tests that slice with start less than negative length works correctly.
+  [] +> tests-slice-with-start-lt-negative-length
+    eq. > @
+      slice.
+        list
+          * 9 99 999 9999
+        -10
+        3
+      * 9 99 999
+
+  # Tests that slice with end less than negative length returns an empty list.
+  [] +> tests-slice-with-end-lt-negative-length
+    eq. > @
+      slice.
+        list
+          * "A" "b" "C" "d" "E"
+        2
+        -9
+      list *
+
+  # Tests that slice with start greater than or equal end (both positive) returns an empty list.
+  [] +> tests-slice-with-start-gte-end-both-positive
+    eq. > @
+      slice.
+        list
+          * 3 "-5" 0 "foo"
+        2
+        0
+      list *
+
+  # Tests that slice with start greater than or equal end (both negative) returns an empty list.
+  [] +> tests-slice-with-start-gte-end-both-negative
+    eq. > @
+      slice.
+        list
+          * 3 92 -423 0 22 943 -22
+        -3
+        -5
+      list *
+
+  # Tests that slice with negative start greater than or equal end returns an empty list.
+  [] +> tests-slice-with-negative-start-gte-end
+    eq. > @
+      slice.
+        list
+          * "f" 1 "b" 2 "b" 3
+        -1
+        3
+      list *
+
+  # Tests that slice with start greater than or equal negative end returns an empty list.
+  [] +> tests-slice-with-start-gte-negative-end
+    eq. > @
+      slice.
+        list
+          * 8 -2 33-53 -1 33 "Y"
+        4
+        -5
+      list *

--- a/objects/org/eolang/structs/map.eo
+++ b/objects/org/eolang/structs/map.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:39

--- a/objects/org/eolang/structs/range-of-numbers.eo
+++ b/objects/org/eolang/structs/range-of-numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:27

--- a/objects/org/eolang/structs/range.eo
+++ b/objects/org/eolang/structs/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:65

--- a/objects/org/eolang/structs/set.eo
+++ b/objects/org/eolang/structs/set.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.structs
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:26

--- a/objects/org/eolang/switch.eo
+++ b/objects/org/eolang/switch.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:44

--- a/objects/org/eolang/sys/getenv.eo
+++ b/objects/org/eolang/sys/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/line-separator.eo
+++ b/objects/org/eolang/sys/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/org/eolang/sys/os.eo
+++ b/objects/org/eolang/sys/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:23

--- a/objects/org/eolang/sys/posix.eo
+++ b/objects/org/eolang/sys/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:28

--- a/objects/org/eolang/sys/win32.eo
+++ b/objects/org/eolang/sys/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.sys
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes:49

--- a/objects/org/eolang/true.eo
+++ b/objects/org/eolang/true.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:12

--- a/objects/org/eolang/try.eo
+++ b/objects/org/eolang/try.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/tuple.eo
+++ b/objects/org/eolang/tuple.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:17

--- a/objects/org/eolang/txt/regex.eo
+++ b/objects/org/eolang/txt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:55

--- a/objects/org/eolang/txt/sprintf.eo
+++ b/objects/org/eolang/txt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint wrong-sprintf-arguments:58

--- a/objects/org/eolang/txt/sscanf.eo
+++ b/objects/org/eolang/txt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+rt jvm org.eolang:eo-runtime:0.58.3
++rt jvm org.eolang:eo-runtime:0.58.6
 +rt node eo2js-runtime:0.0.0
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/org/eolang/txt/text.eo
+++ b/objects/org/eolang/txt/text.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang.txt
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object:24

--- a/objects/org/eolang/while.eo
+++ b/objects/org/eolang/while.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package org.eolang
-+version 0.58.3
++version 0.58.6
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.58.6` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.