### PR TITLE
New release for eo-0.61.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.59.9</eo.version>
+    <eo.version>0.61.0</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -503,6 +503,10 @@
   # Tests that conversion to i64 throws error for wrong-sized bytes.
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
+
+  # Tests that slicing out of bounds throws an error.
+  [] +> throws-on-out-of-bounds-slice
+    20-1F-EE-B5-90.slice 3 10 > @
 
   # Tests that bytes can be correctly converted to i64 integer.
   [] +> tests-bytes-converts-to-i64

--- a/objects/cti.eo
+++ b/objects/cti.eo
@@ -1,9 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 
 # Compile Time Instruction (CTI).
 #
@@ -13,4 +12,14 @@
 # to highlight deprecated methods. EO compiler, when it meets the
 # `cti` object, takes its `message` and prints to the log/console
 # with the `level` severity level (use `INFO`, `WARN`, or `ERROR`).
-delegate > [delegate level message] > cti
+[delegate level message] > cti
+  delegate > @
+
+  # Tests that cti prints warning and returns the delegated value.
+  [] +> tests-prints-warning-and-delegates
+    eq. > @
+      cti
+        2.times 2
+        "warning"
+        "intentional error, ignore it"
+      4

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/error.eo
+++ b/objects/error.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/dir.eo
+++ b/objects/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/fs/file.eo
+++ b/objects/fs/file.eo
@@ -5,9 +5,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/path.eo
+++ b/objects/fs/path.eo
@@ -11,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/tmpdir.eo
+++ b/objects/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/go.eo
+++ b/objects/go.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/io/bytes-as-input.eo
+++ b/objects/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/console.eo
+++ b/objects/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/copied.eo
+++ b/objects/io/copied.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-input.eo
+++ b/objects/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-output.eo
+++ b/objects/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/input-length.eo
+++ b/objects/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/malloc-as-output.eo
+++ b/objects/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -60,20 +60,13 @@
               mem
       01-02-03-04-05-06-07-08-09-A0
 
-  # Tests that writing more bytes than allocated memory throws an error.
-  [] +> throws-on-writing-more-than-allocated
-    malloc.of > @
-      2
-      [m]
-        (malloc-as-output m).write 01-02-03 > @
-
-  [] > writes-larger-data-than-provided-block
+  # Tests that writing more bytes than allocated resizes the block and stores all bytes.
+  [] +> writes-larger-data-than-provided-block
     eq. > @
       malloc.of
         2
         [mem]
-          seq > @
-            *
-              (malloc-as-output mem).write 01-02-03
-              mem
+          seq * > @
+            (malloc-as-output mem).write 01-02-03
+            mem
       01-02-03

--- a/objects/io/stdin.eo
+++ b/objects/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/io/stdout.eo
+++ b/objects/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/tee-input.eo
+++ b/objects/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first
@@ -290,11 +290,14 @@
                 b.put
                   (m.read 0 3).eq "XYX"
 
-  # Tests that malloc throws an error when writing beyond allocated memory bounds with offset.
-  [] +> throws-on-writing-more-than-allocated-to-malloc-with-offset
+  # Tests that malloc resizes the block when writing beyond allocated memory bounds with offset.
+  [] +> writes-beyond-offset-and-resizes
     malloc.of > @
       1
-      m.write 1 true > [m]
+      [m]
+        seq * > @
+          m.write 1 true
+          m.size.eq 2
 
   # Tests that malloc can read data from specific offset with specified length correctly.
   [] +> tests-malloc-reads-with-offset-and-length
@@ -379,14 +382,71 @@
       0
       m.copy 9 1 1 > [m]
 
-  # Tests that malloc throws an error when copying to an invalid target offset.
-  [] +> throws-on-copying-with-wrong-target
+  # Tests that malloc resizes the block when copying to a target offset beyond allocated memory.
+  [] +> copies-and-resizes-to-target
     malloc.for > @
       0
-      m.copy 3 9 1 > [m]
+      [m]
+        seq * > @
+          m.copy 3 9 1
+          m.size.eq 10
 
   # Tests that malloc throws an error when copying with an invalid length parameter.
   [] +> throws-on-copying-with-wrong-length
     malloc.for > @
       0
       m.copy 3 1 9 > [m]
+
+  # Tests that the runtime calculates expressions only once.
+  [] +> tests-calculates-only-once
+    eq. > @
+      malloc.for
+        0
+        # Checks that a is only evaluated once despite multiple negations.
+        [m] > x
+          seq > @
+            *
+              a.neg.neg.neg.neg.eq 42
+              m
+          # Increments the counter and returns 42.
+          [] > a
+            seq > @
+              *
+                ^.m.put (^.m.as-number.plus 1)
+                42
+      1
+
+  # Tests that the runtime handles recursion without arguments.
+  [] +> tests-recursion-without-arguments
+    eq. > @
+      malloc.for 4 [m]>>
+        func m > @
+      0
+    # Decrements n until it reaches zero, then returns it.
+    [n] > func
+      if. > @
+        n.as-number.gt 0
+        seq
+          *
+            n.put (n.as-number.minus 1)
+            ^.func n
+        n
+
+  # Tests that the runtime constants defend against side effects.
+  [] +> tests-constant-defends-against-side-effects
+    eq. > @
+      malloc.for 7 [m]>>
+        m.put > @
+          times.
+            num
+            num
+        number > num
+          ^.inc m > n!
+      64
+    # Increments x and returns its new value.
+    [x] > inc
+      seq > @
+        *
+          x.put
+            x.as-number.plus 1
+          x.as-number

--- a/objects/ms/abs.eo
+++ b/objects/ms/abs.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/acos.eo
+++ b/objects/ms/acos.eo
@@ -4,9 +4,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/angle.eo
+++ b/objects/ms/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ms/asin.eo
+++ b/objects/ms/asin.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/e.eo
+++ b/objects/ms/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/ms/exp.eo
+++ b/objects/ms/exp.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/integral.eo
+++ b/objects/ms/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/ln.eo
+++ b/objects/ms/ln.eo
@@ -1,0 +1,77 @@
++alias ms.abs
++alias ms.e
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ms
++rt jvm org.eolang:eo-runtime:0.61.0
++rt node eo2js-runtime:0.0.0
++version 0.61.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Returns the natural logarithm `num` with base `e` as `org.eolang.number`.
+[num] > ln ?
+  # Tests that natural logarithm of negative float returns NaN.
+  [] +> tests-ln-of-negative-float-is-nan
+    is-nan. +> @
+      ln -2.2
+
+  # Tests that natural logarithm of zero equals negative infinity.
+  [] +> tests-ln-of-zero-is-negative-infinity
+    eq. +> @
+      ln 0
+      negative-infinity
+
+  # Tests that natural logarithm of 1 equals zero.
+  [] +> tests-ln-of-one-is-zero
+    eq. +> @
+      ln 1
+      0
+
+  # Tests that natural logarithm of e equals 1.
+  [] +> tests-ln-of-e-one-is-one
+    eq. +> @
+      ln e
+      1
+
+  # Tests that natural logarithm of -42 equals NaN.
+  [] +> tests-ln-of-negative-int-is-nan
+    is-nan. +> @
+      ln -42
+
+  # Tests that natural logarithm of a positive number > 1.
+  [] +> tests-ln-of-twenty
+    eq. +> @
+      ln 20
+      2.995732273553991
+
+  # Tests that natural logarithm of a fraction (0 < x < 1) is negative.
+  [] +> tests-ln-fraction
+    lt. +> @
+      abs
+        minus.
+          ln 0.5
+          -0.6931471805599453
+      0.00000000001
+
+  # Tests that natural logarithm of positive infinity equals positive infinity.
+  [] +> tests-ln-positive-infinity
+    eq. +> @
+      ln positive-infinity
+      positive-infinity
+
+  # Tests that natural logarithm of negative infinity returns NaN.
+  [] +> tests-ln-negative-infinity
+    is-nan. +> @
+      ln negative-infinity
+
+  # Tests that natural logarithm of NaN returns NaN.
+  [] +> tests-ln-nan
+    is-nan. +> @
+      ln nan
+
+  # Tests that natural logarithm is monotonically increasing.
+  [] +> tests-ln-monotonic
+    lt. +> @
+      ln 2
+      ln 3

--- a/objects/ms/mod.eo
+++ b/objects/ms/mod.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/numbers.eo
+++ b/objects/ms/numbers.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/pi.eo
+++ b/objects/ms/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/ms/pow.eo
+++ b/objects/ms/pow.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/ms/random.eo
+++ b/objects/ms/random.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ms/real.eo
+++ b/objects/ms/real.eo
@@ -1,11 +1,8 @@
-+alias ms.e
 +alias ms.pow
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
-+rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first
@@ -13,9 +10,6 @@
 # Returns a floating point number.
 [num] > real
   num > @
-
-  # Returns the natural logarithm `e` of a `num` as `org.eolang.number`.
-  [] > ln ?
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
@@ -76,57 +70,3 @@
     eq. +> @
       pow 4 5
       1024
-
-  # Tests that natural logarithm of negative float returns NaN.
-  [] +> tests-ln-of-negative-float-is-nan
-    is-nan. +> @
-      ln.
-        real -2.2
-
-  # Tests that natural logarithm of zero equals negative infinity.
-  [] +> tests-ln-of-zero-is-negative-infinity
-    eq. +> @
-      ln.
-        real 0
-      negative-infinity
-
-  # Tests that natural logarithm of 1 equals zero.
-  [] +> tests-ln-of-one-is-zero
-    eq. +> @
-      ln.
-        real 1
-      0
-
-  # Tests that natural logarithm of e equals 1.
-  [] +> tests-ln-of-e-one-is-one
-    eq. +> @
-      ln.
-        real e
-      1
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-negative-int-is-nan
-    is-nan. +> @
-      ln.
-        real -42
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-int-zero-is-negative-infinity
-    eq. +> @
-      ln.
-        real 0
-      negative-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-int-one-is-zero
-    eq. +> @
-      ln.
-        real 1
-      0
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-twenty
-    eq. +> @
-      ln.
-        real 20
-      2.995732273553991

--- a/objects/ms/sqrt.eo
+++ b/objects/ms/sqrt.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name

--- a/objects/negative-infinity.eo
+++ b/objects/negative-infinity.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name

--- a/objects/nk/socket.eo
+++ b/objects/nk/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package nk
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/positive-infinity.eo
+++ b/objects/positive-infinity.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name

--- a/objects/runtime.eo
+++ b/objects/runtime.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.59.9
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint decorated-formation

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/sm/getenv.eo
+++ b/objects/sm/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/sm/line-separator.eo
+++ b/objects/sm/line-separator.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/sm/os.eo
+++ b/objects/sm/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/sm/posix.eo
+++ b/objects/sm/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/sm/win32.eo
+++ b/objects/sm/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes

--- a/objects/ss/bytes-as-array.eo
+++ b/objects/ss/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/eachi.eo
+++ b/objects/ss/eachi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/hash-code-of.eo
+++ b/objects/ss/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/list.eo
+++ b/objects/ss/list.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/map.eo
+++ b/objects/ss/map.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/mapped.eo
+++ b/objects/ss/mapped.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/mappedi.eo
+++ b/objects/ss/mappedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/range-of-numbers.eo
+++ b/objects/ss/range-of-numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/range.eo
+++ b/objects/ss/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/reduced.eo
+++ b/objects/ss/reduced.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/reducedi.eo
+++ b/objects/ss/reducedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/set.eo
+++ b/objects/ss/set.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -1,7 +1,7 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -428,3 +428,15 @@
       "some string"
       7
       5
+
+  # Tests that the runtime unescapes slashes in strings.
+  [] +> tests-unescapes-slashes
+    eq. > @
+      "x\\b\\f\\u\\r\\t\\n\\'"
+      78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+
+  # Tests that the runtime unescapes symbols in strings.
+  [] +> tests-unescapes-symbols
+    eq. > @
+      "\b\f\n\r\t\u27E6"
+      08-0C-0A-0D-09-E2-9F-A6

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -1,9 +1,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint decorated-formation
++unlint compound-name
++unlint formation-without-comment
 
 # The object is a TRUE boolean state.
 [] > true
@@ -59,3 +62,149 @@
         123
         42
       123
+
+  # Tests that the runtime takes parent objects correctly.
+  [] +> tests-takes-parent-object
+    eq. > @
+      a 42
+      42
+    [x] > a
+      take > @
+      [] > take
+        ^.x > @
+
+  # Tests that the runtime takes parent through attribute access.
+  [] +> tests-takes-parent-through-attribute
+    [] > @
+      [] > @
+        [] > @
+          eq. > @
+            x
+            42
+    42 > x
+
+  # Tests that the runtime throws an error when applying to closed objects.
+  [] +> throws-when-applies-to-closed-object
+    closed true > @
+    [x] > a
+      x > @
+    a false > closed
+
+  # Tests that the runtime handles applications that call functions.
+  [] +> tests-app-that-calls-func
+    eq. > @
+      output
+      2
+    [] > app
+      f > @
+        * 1 2 3
+      [args] > f
+        2 > @
+        1 > a
+    app > output
+
+  # Tests that the runtime extracts attributes from decoratees.
+  [] +> tests-extract-attribute-from-decoratee
+    eq. > @
+      a.foo
+      43
+    [foo] > return
+    [] > a
+      ^.return > @
+        plus.
+          42
+          1
+
+  # Tests that the runtime handles deep nesting of objects.
+  [] +> tests-nesting-blah-test
+    blah0 > @
+    [] > blah0
+      blah1 > @
+      [] > blah1
+        blah2 > @
+        [] > blah2
+          blah3 > @
+          [] > blah3
+            blah4 > @
+            [] > blah4
+              blah5 > @
+              [] > blah5
+                blah6 > @
+                [] > blah6
+                  blah7 > @
+                  [] > blah7
+                    blah8 > @
+                    [] > blah8
+                      blah9 > @
+                      [] > blah9
+                        blah10 > @
+                        [] > blah10
+                          blah11 > @
+                          [] > blah11
+                            blah12 > @
+                            [] > blah12
+                              blah13 > @
+                              [] > blah13
+                                blah14 > @
+                                [] > blah14
+                                  blah15 > @
+                                  [] > blah15
+                                    blah16 > @
+                                    [] > blah16
+                                      blah17 > @
+                                      [] > blah17
+                                        blah18 > @
+                                        [] > blah18
+                                          blah19 > @
+                                          [] > blah19
+                                            blah20 > @
+                                            [] > blah20
+                                              blah21 > @
+                                              [] > blah21
+                                                blah22 > @
+                                                [] > blah22
+                                                  blah23 > @
+                                                  [] > blah23
+                                                    blah24 > @
+                                                    [] > blah24
+                                                      blah25 > @
+                                                      [] > blah25
+                                                        blah26 > @
+                                                        [] > blah26
+                                                          blah27 > @
+                                                          [] > blah27
+                                                            blah28 > @
+                                                            [] > blah28
+                                                              blah29 > @
+                                                              [] > blah29
+                                                                blah30 > @
+                                                                [] > blah30
+                                                                  blah31 > @
+                                                                  [] > blah31
+                                                                    blah32 > @
+                                                                    [] > blah32
+                                                                      blah33 > @
+                                                                      [] > blah33
+                                                                        blah34 > @
+                                                                        [] > blah34
+                                                                          blah35 > @
+                                                                          [] > blah35
+                                                                            blah36 > @
+                                                                            [] > blah36
+                                                                              blah37 > @
+                                                                              [] > blah37
+                                                                                blah38 > @
+                                                                                [] > blah38
+                                                                                  blah39 > @
+                                                                                  [] > blah39
+                                                                                    true > @
+
+  # Tests that the runtime compiles correctly with long duplicate names.
+  [] +> tests-compiles-correctly-with-long-duplicate-names
+    true > @
+    [] > long-object-name
+      [] > long-object-name
+        [] > long-object-name
+          [] > long-object-name
+            [] > long-object-name
+              42 > x

--- a/objects/try.eo
+++ b/objects/try.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/tt/as-number.eo
+++ b/objects/tt/as-number.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/at.eo
+++ b/objects/tt/at.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/chained.eo
+++ b/objects/tt/chained.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-all.eo
+++ b/objects/tt/contains-all.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-any.eo
+++ b/objects/tt/contains-any.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains.eo
+++ b/objects/tt/contains.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/ends-with.eo
+++ b/objects/tt/ends-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/index-of.eo
+++ b/objects/tt/index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alpha.eo
+++ b/objects/tt/is-alpha.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alphanumeric.eo
+++ b/objects/tt/is-alphanumeric.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-ascii.eo
+++ b/objects/tt/is-ascii.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/joined.eo
+++ b/objects/tt/joined.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/last-index-of.eo
+++ b/objects/tt/last-index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/low-cased.eo
+++ b/objects/tt/low-cased.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tt/nsplit.eo
+++ b/objects/tt/nsplit.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/regex.eo
+++ b/objects/tt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tt/repeated.eo
+++ b/objects/tt/repeated.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/replaced.eo
+++ b/objects/tt/replaced.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/slice.eo
+++ b/objects/tt/slice.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/split.eo
+++ b/objects/tt/split.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/sprintf.eo
+++ b/objects/tt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/tt/sscanf.eo
+++ b/objects/tt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.0
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint idempotent-attribute-is-not-first

--- a/objects/tt/starts-with.eo
+++ b/objects/tt/starts-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/string-buffer.eo
+++ b/objects/tt/string-buffer.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-left.eo
+++ b/objects/tt/trimmed-left.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-right.eo
+++ b/objects/tt/trimmed-right.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed.eo
+++ b/objects/tt/trimmed.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/up-cased.eo
+++ b/objects/tt/up-cased.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.61.0` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.