### PR TITLE
New release for eo-0.61.1

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.59.9</eo.version>
+    <eo.version>0.61.1</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -1,14 +1,12 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # The object encapsulates a chain of bytes, providing bitwise operations,
 # numeric conversions, and byte manipulation methods. Objects like `number`, `string`,
@@ -73,34 +71,34 @@
 
   # Returns `org.eolang.true` if current sequence of bytes equals another object.
   # Before the actual comparison the object `b` is dataized.
-  [b] > eq ?
+  [b] > eq /true
 
   # Returns total amount of current bytes as `org.eolang.number`.
-  [] > size ?
+  [] > size /number
 
   # Represents a sub-sequence of `org.eolang.bytes` inside the current one.
-  [start len] > slice ?
+  [start len] > slice /bytes
 
   # Calculates the bitwise AND operation and returns result as `org.eolang.bytes`.
-  [b] > and ?
+  [b] > and /bytes
 
   # Calculates the bitwise OR operation and returns result as `org.eolang.bytes`.
-  [b] > or ?
+  [b] > or /bytes
 
   # Calculates the bitwise XOR operation and returns result as `org.eolang.bytes`.
-  [b] > xor ?
+  [b] > xor /bytes
 
   # Calculates the bitwise NOT operation and returns result as `org.eolang.bytes`.
-  [] > not ?
+  [] > not /bytes
 
   # Calculates the bitwise left shift.
   right x.neg > [x] > left
 
   # Calculates the bitwise right shift and returns result as `org.eolang.bytes`.
-  [x] > right ?
+  [x] > right /bytes
 
   # Concatenation of two byte sequences and returns result as `org.eolang.bytes`.
-  [b] > concat ?
+  [b] > concat /bytes
 
   # Tests that a slice of bytes can be extracted from a larger byte sequence.
   [] +> tests-takes-part-of-bytes
@@ -503,6 +501,10 @@
   # Tests that conversion to i64 throws error for wrong-sized bytes.
   [] +> throws-on-bytes-of-wrong-size-as-i64
     01-01-01-01.as-i64 > @
+
+  # Tests that slicing out of bounds throws an error.
+  [] +> throws-on-out-of-bounds-slice
+    20-1F-EE-B5-90.slice 3 10 > @
 
   # Tests that bytes can be correctly converted to i64 integer.
   [] +> tests-bytes-converts-to-i64

--- a/objects/cti.eo
+++ b/objects/cti.eo
@@ -1,9 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint unit-test-missing
 
 # Compile Time Instruction (CTI).
 #
@@ -13,4 +12,14 @@
 # to highlight deprecated methods. EO compiler, when it meets the
 # `cti` object, takes its `message` and prints to the log/console
 # with the `level` severity level (use `INFO`, `WARN`, or `ERROR`).
-delegate > [delegate level message] > cti
+[delegate level message] > cti
+  delegate > @
+
+  # Tests that cti prints warning and returns the delegated value.
+  [] +> tests-prints-warning-and-delegates
+    eq. > @
+      cti
+        2.times 2
+        "warning"
+        "intentional error, ignore it"
+      4

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/error.eo
+++ b/objects/error.eo
@@ -1,16 +1,15 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
-+unlint idempotent-attribute-is-not-first
 
 # This object must be used in order to terminate the program
 # with an error. To use it, make a copy with an encapsulated object as the error message.
 # The first attempt to dataize it will lead to runtime error and program
 # termination. The only way to catch such an error is by using
 # the `try` object.
-[message] > error ?
+[message] > error /error

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/dir.eo
+++ b/objects/fs/dir.eo
@@ -3,13 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 +unlint redundant-object
 
 # Directory in the file system.
@@ -34,12 +32,12 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use it programmatically outside of `dir` object.
-    [] > mkdir ?
+    [] > mkdir /true
 
   # Goes through all files in the directory, recursively
   # finding them with the `glob` provided.
   # Returns `org.eolang.tuple` of all files in the directory.
-  [glob] > walk ?
+  [glob] > walk /tuple
 
   # Deletes directory and all files in it, recursively.
   # Returns the deleted directory.
@@ -80,7 +78,7 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of the `dir` object.
-    [] > touch ?
+    [] > touch /string
 
   # Opens the file for I/O operations.
   # Since current file is a directory - returns an `error`.

--- a/objects/fs/file.eo
+++ b/objects/fs/file.eo
@@ -5,14 +5,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # The file object in the filesystem.
 [path] > file
@@ -21,10 +19,10 @@
   (Q.fs.path path).@ > as-path
 
   # Returns `org.eolang.true` if current file is a directory, returns `org.eolang.false` otherwise.
-  [] > is-directory ?
+  [] > is-directory /true
 
   # Returns `org.eolang.true` if file with current `path` exists in filesystem.
-  [] > exists ?
+  [] > exists /true
 
   # If current file exists - returns the file.
   # If current file does not exist - create an empty file
@@ -41,7 +39,7 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
-    [] > touch ?
+    [] > touch /true
 
   # If current file exists - deletes it and returns it.
   # If current file does not exist - just returns it.
@@ -57,10 +55,10 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
-    [] > delete ?
+    [] > delete /true
 
   # Gets the file size in bytes and returns it as `org.eolang.number`.
-  [] > size ?
+  [] > size /number
 
   # Moves the current file to `target`, making and returning a new `file` from it.
   [target] > moved
@@ -73,7 +71,7 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of `file` object.
-    [] > move ?
+    [] > move /string
 
   # Opens the file.
   #
@@ -165,7 +163,7 @@
     #
     # Note: This object is intended for internal use only. Please
     # don't use the object programmatically outside of the `file` object.
-    [] > process-file ?
+    [] > process-file /true
 
     # File stream.
     # The objects provides an API for using file as input or output.
@@ -204,7 +202,7 @@
         #
         # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
-        [size] > chunk ?
+        [size] > chunk /bytes
 
       # Writes the given `buffer` to file output stream.
       # Here `buffer` is either a sequence of bytes or an object that can be
@@ -242,7 +240,7 @@
         #
         # Note: This object is intended for internal use only. Please
         # don't use the object programmatically outside of `file` object.
-        [buffer] > written-bytes ?
+        [buffer] > written-bytes /true
 
   # Tests that the current directory is detected as a directory.
   [] +> tests-check-if-current-directory-is-directory
@@ -507,16 +505,18 @@
         f.write "Shrek is love" > [f]
       eq.
         "Shrek is love"
-        malloc.of 13 [m]>>
-          seq * > @
-            file
-              ^.src
-            .open
-              "r"
-              [f] >>
-                ^.m.put > @
-                  f.read 13
-            m
+        malloc.of
+          13
+          [m] >>
+            seq * > @
+              file
+                ^.src
+              .open
+                "r"
+                [f] >>
+                  ^.m.put > @
+                    f.read 13
+              m
     tmpdir.tmpfile > temp
     temp.path > src
 

--- a/objects/fs/path.eo
+++ b/objects/fs/path.eo
@@ -11,11 +11,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint compound-name
++unlint ascii-only
 
 # A `path` represents a path that is hierarchical and composed of a sequence of
 # directory and file name elements separated by a special separator or delimiter.

--- a/objects/fs/tmpdir.eo
+++ b/objects/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/go.eo
+++ b/objects/go.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -1,13 +1,11 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 +unlint redundant-object
 
 # The 16 bits signed integer.
@@ -22,7 +20,7 @@
   # The object is an atom because it's not possible to check what
   # bytes should be added from left so the number is valid.
   # The different bytes should be added if number is positive and negative.
-  [] > as-i32 ?
+  [] > as-i32 /i32
 
   # Returns `org.eolang.true` if `$` < `x`.
   # Here `x` must be an `org.eolang.i16` object.

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -1,13 +1,11 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 +unlint redundant-object
 
 # The 32 bits signed integer.
@@ -21,7 +19,7 @@
   # The object is an atom because it's not possible to check what
   # bytes should be added from left so the number is valid.
   # The different bytes should be added if number is positive and negative.
-  [] > as-i64 ?
+  [] > as-i64 /i64
 
   # Convert this `org.eolang.i32` to `org.eolang.i16`.
   # The `org.eolang.error` is returned if the `org.eolang.i32` number is more than

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -1,13 +1,11 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 +unlint redundant-object
 
 # The 64 bits signed integer.
@@ -33,7 +31,7 @@
     (as-bytes.slice 0 4).as-bytes > left
 
   # Convert this `org.eolang.i64` to `org.eolang.number` object and return it.
-  [] > as-number ?
+  [] > as-number /number
 
   # Returns `org.eolang.true` if `$` < `x`.
   # Here `x` must be an `org.eolang.i64` object.
@@ -53,7 +51,7 @@
 
   # Returns `org.eolang.true` if `$` > `x`.
   # Here `x` must be an `org.eolang.i64` object.
-  [x] > gt ?
+  [x] > gt /true
 
   # Returns `org.eolang.true` if `$` >= `x`.
   # Here `x` must be an `org.eolang.i64` object.
@@ -65,11 +63,11 @@
 
   # Multiplication of `$` and `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
-  [x] > times ?
+  [x] > times /i64
 
   # Sum of `$` and `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
-  [x] > plus ?
+  [x] > plus /i64
 
   # Subtraction between `$` and `x`.
   # Here `x` must be an `i64` object.
@@ -80,7 +78,7 @@
   # Quotient of the division of `$` by `x` as `org.eolang.i64`.
   # Here `x` must be an `org.eolang.i64` object.
   # An `org.eolang.error` is returned if `x` is equal to 0.
-  [x] > div ?
+  [x] > div /i64
 
   # Tests that i64 number has correct byte representation.
   [] +> tests-i64-has-valid-bytes

--- a/objects/io/bytes-as-input.eo
+++ b/objects/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/console.eo
+++ b/objects/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/copied.eo
+++ b/objects/io/copied.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-input.eo
+++ b/objects/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-output.eo
+++ b/objects/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/input-as-bytes.eo
+++ b/objects/io/input-as-bytes.eo
@@ -1,0 +1,37 @@
++alias io.copied
++alias io.malloc-as-output
++alias io.bytes-as-input
++alias io.dead-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package io
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Reads all bytes from the provided `input` and returns them as bytes.
+#
+# Example usage:
+# ```
+# input-as-bytes > bts
+#   bytes-as-input 01-02-03-04-05
+# ```
+# After dataization, `bts` equals `01-02-03-04-05`.
+[input] > input-as-bytes
+  malloc.of > @
+    0
+    [m] >>
+      seq * > @
+        copied input (malloc-as-output m)
+        m
+
+  # Tests that input-as-bytes reads all bytes from input and returns them.
+  [] +> tests-bytes-to-input-and-back
+    eq. > @
+      input-as-bytes (bytes-as-input bts)
+      bts
+    01-02-03-04-05-06-07-08 > bts
+
+  # Tests that input-as-bytes returns empty bytes from dead input.
+  [] +> tests-returns-empty-bytes-from-dead-input
+    (input-as-bytes dead-input).eq -- > @

--- a/objects/io/input-length.eo
+++ b/objects/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/malloc-as-output.eo
+++ b/objects/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -60,20 +60,13 @@
               mem
       01-02-03-04-05-06-07-08-09-A0
 
-  # Tests that writing more bytes than allocated memory throws an error.
-  [] +> throws-on-writing-more-than-allocated
-    malloc.of > @
-      2
-      [m]
-        (malloc-as-output m).write 01-02-03 > @
-
-  [] > writes-larger-data-than-provided-block
+  # Tests that writing more bytes than allocated resizes the block and stores all bytes.
+  [] +> writes-larger-data-than-provided-block
     eq. > @
       malloc.of
         2
         [mem]
-          seq > @
-            *
-              (malloc-as-output mem).write 01-02-03
-              mem
+          seq * > @
+            (malloc-as-output mem).write 01-02-03
+            mem
       01-02-03

--- a/objects/io/stdin.eo
+++ b/objects/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/io/stdout.eo
+++ b/objects/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/tee-input.eo
+++ b/objects/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -75,12 +75,15 @@
         [m]
           seq > @
             *
-              tee-input
-                bytes-as-input 01-02-03-04-05
-                malloc-as-output m
-              .read 2
-              .read 2
-              .read 1
+              read.
+                read.
+                  read.
+                    tee-input
+                      bytes-as-input 01-02-03-04-05
+                      malloc-as-output m
+                    2
+                  2
+                1
               m
       01-02-03-04-05
 

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -1,11 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # The `malloc` object is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may
@@ -82,7 +81,7 @@
   # written into memory.
   [size scope] > of
     # Dataizes given `scope` and returns the result of the dataization as `org.eolang.bytes`.
-    [] > @ ?
+    [] > @ /bytes
 
     # Allocated block in memory that provides an API for writing and reading.
     [id] > allocated
@@ -91,13 +90,13 @@
       read 0 size > get
 
       # Returns size of allocated block in memory as `org.eolang.number`.
-      [] > size ?
+      [] > size /number
 
       # Resizes allocated block in memory and returns `true`.
       # Here `size` must be positive `number`.
       # The `error` returned if failed to resize block in memory.
       # Returns `org.eolang.malloc.of.allocated` object.
-      [size] > resized ?
+      [size] > resized /allocated
 
       # Reads the data from block in memory with offset `source` and `length` and writes
       # to the block with offset `target`.
@@ -109,11 +108,11 @@
 
       # Read `length` bytes with `offset` from the allocated block in memory and return them
       # as `org.eolang.bytes`.
-      [offset length] > read ?
+      [offset length] > read /bytes
 
       # Write `data` with `offset` to the allocated block in memory
       # and return `org.eolang.true`.
-      [offset data] > write ?
+      [offset data] > write /true
 
       # Put `object` into the allocated block in memory. The `object` is supposed to be dataizable.
       [object] > put
@@ -290,11 +289,14 @@
                 b.put
                   (m.read 0 3).eq "XYX"
 
-  # Tests that malloc throws an error when writing beyond allocated memory bounds with offset.
-  [] +> throws-on-writing-more-than-allocated-to-malloc-with-offset
+  # Tests that malloc resizes the block when writing beyond allocated memory bounds with offset.
+  [] +> writes-beyond-offset-and-resizes
     malloc.of > @
       1
-      m.write 1 true > [m]
+      [m]
+        seq * > @
+          m.write 1 true
+          m.size.eq 2
 
   # Tests that malloc can read data from specific offset with specified length correctly.
   [] +> tests-malloc-reads-with-offset-and-length
@@ -379,14 +381,75 @@
       0
       m.copy 9 1 1 > [m]
 
-  # Tests that malloc throws an error when copying to an invalid target offset.
-  [] +> throws-on-copying-with-wrong-target
+  # Tests that malloc resizes the block when copying to a target offset beyond allocated memory.
+  [] +> copies-and-resizes-to-target
     malloc.for > @
       0
-      m.copy 3 9 1 > [m]
+      [m]
+        seq * > @
+          m.copy 3 9 1
+          m.size.eq 10
 
   # Tests that malloc throws an error when copying with an invalid length parameter.
   [] +> throws-on-copying-with-wrong-length
     malloc.for > @
       0
       m.copy 3 1 9 > [m]
+
+  # Tests that the runtime calculates expressions only once.
+  [] +> tests-calculates-only-once
+    eq. > @
+      malloc.for
+        0
+        # Checks that a is only evaluated once despite multiple negations.
+        [m] > x
+          seq > @
+            *
+              a.neg.neg.neg.neg.eq 42
+              m
+          # Increments the counter and returns 42.
+          [] > a
+            seq > @
+              *
+                ^.m.put (^.m.as-number.plus 1)
+                42
+      1
+
+  # Tests that the runtime handles recursion without arguments.
+  [] +> tests-recursion-without-arguments
+    eq. > @
+      malloc.for
+        4
+        [m] >>
+          func m > @
+      0
+    # Decrements n until it reaches zero, then returns it.
+    [n] > func
+      if. > @
+        n.as-number.gt 0
+        seq
+          *
+            n.put (n.as-number.minus 1)
+            ^.func n
+        n
+
+  # Tests that the runtime constants defend against side effects.
+  [] +> tests-constant-defends-against-side-effects
+    eq. > @
+      malloc.for
+        7
+        [m] >>
+          m.put > @
+            times.
+              num
+              num
+          number > num
+            ^.inc m > n!
+      64
+    # Increments x and returns its new value.
+    [x] > inc
+      seq > @
+        *
+          x.put
+            x.as-number.plus 1
+          x.as-number

--- a/objects/ms/abs.eo
+++ b/objects/ms/abs.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,30 +15,30 @@
 
   # Tests that absolute value of positive integer is the integer itself.
   [] +> tests-abs-int-positive
-    eq. +> @
+    eq. > @
       abs 3
       3
 
   # Tests that absolute value of negative integer removes the sign.
   [] +> tests-abs-int-negative
-    eq. +> @
+    eq. > @
       abs -3
       3
 
   # Tests that absolute value of zero is zero.
   [] +> tests-abs-zero
-    eq. +> @
+    eq. > @
       abs 0
       0
 
   # Tests that absolute value of positive float is the float itself.
   [] +> tests-abs-float-positive
-    eq. +> @
+    eq. > @
       abs 13.5
       13.5
 
   # Tests that absolute value of negative float removes the sign.
   [] +> tests-abs-float-negative
-    eq. +> @
+    eq. > @
       abs -17.9
       17.9

--- a/objects/ms/acos.eo
+++ b/objects/ms/acos.eo
@@ -4,23 +4,23 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Calculates arc cosine of a `num` as `org.eolang.number`.
-[num] > acos ?
+[num] > acos /number
   # Tests that arccosine of -1 equals pi.
   [] +> tests-arccos-negative-one-test
-    eq. +> @
+    eq. > @
       acos -1.0
       pi
 
   # Tests that arccosine of 0 equals pi/2.
   [] +> tests-arccos-zero-test
-    eq. +> @
+    eq. > @
       acos 0
       div.
         pi
@@ -28,13 +28,13 @@
 
   # Tests that arccosine of 1 equals zero.
   [] +> tests-arccos-one-test
-    eq. +> @
+    eq. > @
       acos 1.0
       0
 
   # Tests acos calculation for a positive value inside [-1,1].
   [] +> tests-arccos-positive-calculated-test
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -44,7 +44,7 @@
 
   # Tests acos calculation for a negative value inside [-1,1].
   [] +> tests-arccos-negative-calculated-test
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -54,25 +54,25 @@
 
   # Tests that acos returns NaN for a positive value outside [-1,1].
   [] +> tests-arccos-nan-positive-value-test
-    is-nan. +> @
+    is-nan. > @
       acos 2.0
 
   # Tests that acos returns NaN for a negative value outside [-1,1].
   [] +> tests-arccos-nan-negative-value-test
-    is-nan. +> @
+    is-nan. > @
       acos -2.0
 
   # Tests that arccosine of NaN is NaN.
   [] +> tests-arccos-nan-input
-    is-nan. +> @
+    is-nan. > @
       acos nan
 
   # Tests that arccosine of positive-infinity is NaN.
   [] +> tests-arccos-positive-infinity
-    is-nan. +> @
+    is-nan. > @
       acos positive-infinity
 
   # Tests that arccosine of negative-infinity is NaN.
   [] +> tests-arccos-negative-infinity
-    is-nan. +> @
+    is-nan. > @
       acos negative-infinity

--- a/objects/ms/angle.eo
+++ b/objects/ms/angle.eo
@@ -2,13 +2,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
 
 # The angle.
 # A measure of how much something is tilted or rotated, measured in degrees or radians.
@@ -28,11 +27,11 @@
 
   # Calculates sine of current angle and returns it as `org.eolang.number`.
   # Please note, that `sin` is calculated from the angle in radians.
-  [] > sin ?
+  [] > sin /number
 
   # Calculates cosine of current angle and returns it as `org.eolang.number`.
   # Please note, that `cos` is calculated from the angle in radians.
-  [] > cos ?
+  [] > cos /number
 
   # Tangent of current angle.
   # Please note, that `tan` is calculated from the angle in radians.

--- a/objects/ms/asin.eo
+++ b/objects/ms/asin.eo
@@ -3,23 +3,23 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # An operation that finds the angle whose sine is `num`.
-[num] > asin ?
+[num] > asin /number
   # Tests that asin by zero equals zero.
   [] +> tests-asin-zero
-    eq. +> @
+    eq. > @
       asin 0
       0
 
   # Tests that asin of 1 equals pi/2.
   [] +> tests-asin-one
-    eq. +> @
+    eq. > @
       asin 1
       div.
         pi
@@ -27,7 +27,7 @@
 
   # Tests that asin of -1 equals -pi/2.
   [] +> tests-asin-negative-one
-    eq. +> @
+    eq. > @
       asin -1
       minus.
         0
@@ -37,7 +37,7 @@
 
   # Tests that asin of 0.5 equals 0.5235987756.
   [] +> tests-asin-positive-value
-    lt. +> @
+    lt. > @
       abs
         minus.
           asin 0.5
@@ -46,7 +46,7 @@
 
   # Tests that asin of -0.5 equals -0.5235987756.
   [] +> tests-asin-negative-value
-    lt. +> @
+    lt. > @
       abs
         minus.
           asin -0.5
@@ -55,25 +55,25 @@
 
   # Tests that asin of value > 1 equals NaN.
   [] +> tests-asin-out-of-range-positive
-    is-nan. +> @
+    is-nan. > @
       asin 2
 
   # Tests that asin of value < -1 equals NaN.
   [] +> tests-asin-out-of-range-negative
-    is-nan. +> @
+    is-nan. > @
       asin -2
 
   # Tests that asin of NaN equals NaN.
   [] +> tests-asin-nan
-    is-nan. +> @
+    is-nan. > @
       asin nan
 
   # Tests that asin of +inf equals NaN.
   [] +> tests-asin-positive-infinity
-    is-nan. +> @
+    is-nan. > @
       asin positive-infinity
 
   # Tests that asin of -inf equals NaN.
   [] +> tests-asin-negative-infinity
-    is-nan. +> @
+    is-nan. > @
       asin negative-infinity

--- a/objects/ms/e.eo
+++ b/objects/ms/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/ms/exp.eo
+++ b/objects/ms/exp.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -15,7 +15,7 @@
 
   # Tests that exponential function e^1 approximately equals e.
   [] +> tests-exp-check-n0
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -25,7 +25,7 @@
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n1
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -35,7 +35,7 @@
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n2
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -45,7 +45,7 @@
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-n3
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -55,17 +55,17 @@
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-nan
-    is-nan. +> @
+    is-nan. > @
       exp nan
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-infinity-n1
-    eq. +> @
+    eq. > @
       exp positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-exp-check-infinity-n2
-    eq. +> @
+    eq. > @
       exp negative-infinity
       0

--- a/objects/ms/integral.eo
+++ b/objects/ms/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/ln.eo
+++ b/objects/ms/ln.eo
@@ -1,0 +1,77 @@
++alias ms.abs
++alias ms.e
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ms
++rt jvm org.eolang:eo-runtime:0.61.1
++rt node eo2js-runtime:0.0.0
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Returns the natural logarithm `num` with base `e` as `org.eolang.number`.
+[num] > ln /number
+  # Tests that natural logarithm of negative float returns NaN.
+  [] +> tests-ln-of-negative-float-is-nan
+    is-nan. > @
+      ln -2.2
+
+  # Tests that natural logarithm of zero equals negative infinity.
+  [] +> tests-ln-of-zero-is-negative-infinity
+    eq. > @
+      ln 0
+      negative-infinity
+
+  # Tests that natural logarithm of 1 equals zero.
+  [] +> tests-ln-of-one-is-zero
+    eq. > @
+      ln 1
+      0
+
+  # Tests that natural logarithm of e equals 1.
+  [] +> tests-ln-of-e-one-is-one
+    eq. > @
+      ln e
+      1
+
+  # Tests that natural logarithm of -42 equals NaN.
+  [] +> tests-ln-of-negative-int-is-nan
+    is-nan. > @
+      ln -42
+
+  # Tests that natural logarithm of a positive number > 1.
+  [] +> tests-ln-of-twenty
+    eq. > @
+      ln 20
+      2.995732273553991
+
+  # Tests that natural logarithm of a fraction (0 < x < 1) is negative.
+  [] +> tests-ln-fraction
+    lt. > @
+      abs
+        minus.
+          ln 0.5
+          -0.6931471805599453
+      0.00000000001
+
+  # Tests that natural logarithm of positive infinity equals positive infinity.
+  [] +> tests-ln-positive-infinity
+    eq. > @
+      ln positive-infinity
+      positive-infinity
+
+  # Tests that natural logarithm of negative infinity returns NaN.
+  [] +> tests-ln-negative-infinity
+    is-nan. > @
+      ln negative-infinity
+
+  # Tests that natural logarithm of NaN returns NaN.
+  [] +> tests-ln-nan
+    is-nan. > @
+      ln nan
+
+  # Tests that natural logarithm is monotonically increasing.
+  [] +> tests-ln-monotonic
+    lt. > @
+      ln 2
+      ln 3

--- a/objects/ms/mod.eo
+++ b/objects/ms/mod.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
@@ -31,44 +31,45 @@
 
   # Tests that modulo operation works correctly for 1 mod 2.
   [] +> tests-mod-n1-n2
-    eq. +> @
+    eq. > @
       mod 1 2
       1
 
   # Tests that modulo operation works correctly for 0 mod 5.
   [] +> tests-mod-n0-n5
-    eq. +> @
+    eq. > @
       mod 0 5
       0
 
   # Tests that modulo operation works correctly for 0 mod -15.
   [] +> tests-mod-n0-n15-neg
-    eq. +> @
+    eq. > @
       mod 0 -15
       0
 
   # Tests that modulo operation works correctly for -1 mod 7.
   [] +> tests-mod-n1-neg-n7
-    eq. +> @
+    eq. > @
       mod -1 7
       -1
 
   # Tests that modulo operation works correctly for 16 mod -200.
   [] +> tests-mod-n16-n200-neg
-    eq. +> @
+    eq. > @
       mod 16 -200
       16
 
-  # Tests mathematical equality A = ((A div B) * B) + (A mod B).
-  # Checks mathematical equality
-  # A = ((A div B) * B) + (A mod B).
+  # Tests mathematical equality A = (trunc(A / B) * B) + (A mod B).
+  # `mod` follows the sign of the dividend (truncated remainder, like C `%`),
+  # so the matching quotient is truncation toward zero (`as-i64`), not
+  # mathematical floor.
   [] +> tests-div-mod-compatibility
-    eq. +> @
+    eq. > @
       plus.
         mod dividend divisor
         times.
           divisor
-          (dividend.div divisor).floor
+          (dividend.div divisor).as-i64.as-number
       dividend
     -13 > dividend
     5 > divisor
@@ -76,13 +77,13 @@
   # Tests modulo operation when dividend is less than divisor.
   # Checks modulo: dividend < divisor.
   [] +> tests-mod-dividend-less-than-divisor
-    eq. +> @
+    eq. > @
       mod -1 5
       -1
 
   # Tests modulo operation when divisor is 1.
   # Checks modulo by 1.
   [] +> tests-mod-dividend-by-one
-    eq. +> @
+    eq. > @
       mod 133 1
       0

--- a/objects/ms/numbers.eo
+++ b/objects/ms/numbers.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/pi.eo
+++ b/objects/ms/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/ms/pow.eo
+++ b/objects/ms/pow.eo
@@ -1,196 +1,195 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # An operation that raises `num` to the power of `x`.
-[num x] > pow ?
+[num x] > pow /number
   # Tests that power operation works correctly for 2^4.
   [] +> tests-pow-test
-    eq. +> @
+    eq. > @
       pow 2 4
       16
 
   # Tests that any number raised to the power of zero equals 1.
   [] +> tests-pow-is-zero
-    eq. +> @
+    eq. > @
       pow 2 0
       1
 
   # Tests that large number raised to large negative power approaches zero.
   [] +> tests-pow-is-negative
-    eq. +> @
+    eq. > @
       pow 984782 -12341
       0
 
   # Tests that 3 raised to the power of 2 equals 9.
   [] +> tests-pow-of-two
-    eq. +> @
+    eq. > @
       pow 3 2
       9
 
   # Tests that zero raised to any positive power equals zero.
   [] +> tests-pow-of-zero
-    eq. +> @
+    eq. > @
       pow 0 145
       0
 
   # Tests that zero raised to negative power throws error.
   [] +> throws-on-negative-pow-of-zero
-    pow 0 -567 +> @
+    pow 0 -567 > @
 
   # Tests that NaN raised to NaN power results in NaN.
   # Check pow works with NaNs.
   [] +> tests-nan-to-the-pow-of-nan-is-nan
-    is-nan. +> @
+    is-nan. > @
       pow nan nan
 
   # Tests that NaN raised to any power results in NaN.
   [] +> tests-nan-to-the-pow-of-any-is-nan
-    is-nan. +> @
+    is-nan. > @
       pow nan 42
 
   # Tests that any number raised to NaN power results in NaN.
   [] +> tests-any-to-the-pow-of-nan-is-nan
-    is-nan. +> @
+    is-nan. > @
       pow 52 nan
 
   # Tests that any integer raised to the power of zero equals 1.
   # Check if pow is zero.
   [] +> tests-any-int-to-the-pow-of-zero-is-one
-    eq. +> @
+    eq. > @
       pow 42 0
       1
 
   # Tests that any float raised to the power of zero equals 1.
   [] +> tests-any-float-to-the-pow-of-zero-is-one
-    eq. +> @
+    eq. > @
       pow 42.5 0
       1
 
   # Tests that zero raised to negative power equals positive infinity.
   # Check if pow is less than zero.
   [] +> tests-zero-to-the-negative-pow-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow 0 -52
       positive-infinity
 
   # Tests that zero raised to negative infinity equals positive infinity.
   [] +> tests-zero-to-the-negative-infinity-pow-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow 0 negative-infinity
       positive-infinity
 
   # Tests that positive integer raised to negative infinity equals zero.
   [] +> tests-positive-int-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow 42 negative-infinity
       0
 
   # Tests that positive float raised to negative infinity equals zero.
   [] +> tests-positive-float-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow 42.5 negative-infinity
       0
 
   # Tests that negative integer raised to negative infinity equals zero.
   [] +> tests-negative-int-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow -42 negative-infinity
       0
 
   # Tests that negative float raised to negative infinity equals zero.
   [] +> tests-negative-float-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow -42.5 negative-infinity
       0
 
   # Tests that positive infinity raised to negative infinity equals zero.
   [] +> tests-positive-infinity-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow positive-infinity negative-infinity
       0
 
   # Tests that negative infinity raised to negative infinity equals zero.
   [] +> tests-negative-infinity-to-the-pow-of-negative-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow negative-infinity negative-infinity
       0
 
   # Tests that positive infinity raised to finite negative power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-int-pow-is-zero
-    eq. +> @
+    eq. > @
       pow positive-infinity -42
       0
 
   # Tests that positive infinity raised to finite negative float power equals zero.
   [] +> tests-positive-infinity-to-the-finite-negative-float-pow-is-zero
-    eq. +> @
+    eq. > @
       pow positive-infinity -42.2
       0.0
 
   # Tests that 2 raised to the power of -1 equals 0.5.
   [] +> tests-two-to-the-pow-of-minus-one
-    eq. +> @
+    eq. > @
       pow 2 -1
       0.5
 
   # Tests that 2 raised to the power of -2 equals 0.25.
   [] +> tests-two-to-the-pow-of-int-minus-two
-    eq. +> @
+    eq. > @
       pow 2 -2
       0.25
 
   # Tests mathematical operation functionality.
   [] +> tests-two-to-the-pow-of-minus-three
-    eq. +> @
+    eq. > @
       pow 2 -3
       0.125
 
   # Tests mathematical operation functionality.
   [] +> tests-four-to-the-pow-of-minus-three
-    eq. +> @
+    eq. > @
       pow 4 -3.0
       0.015625
 
   # Tests mathematical operation functionality.
   # Check if pow more than zero.
   [] +> tests-zero-to-the-pow-of-positive-int-is-zero
-    eq. +> @
+    eq. > @
       pow 0 4
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-zero-to-the-pow-of-positive-float-is-zero
-    eq. +> @
+    eq. > @
       pow 0 4.2
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-zero-to-the-pow-of-positive-infinity-is-zero
-    eq. +> @
+    eq. > @
       pow 0 positive-infinity
       0
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-int-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow -10 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-float-to-the-pow-of-positive-infinity-is-infinity
-    eq. +> @
+    eq. > @
       pow -4.2 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow 42 positive-infinity
       positive-infinity

--- a/objects/ms/random.eo
+++ b/objects/ms/random.eo
@@ -1,10 +1,8 @@
-+alias sm.os
-+alias sm.posix
-+alias sm.win32
++alias sm.system-clock
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -33,8 +31,9 @@
               11
           00-0F-FF-FF-FF-FF-FF-FF
 
-  # New random with pseudo-random seed.
-  [] > pseudo
+  # Builds a `random` whose seed is derived from the wall-clock time provided by `clock`.
+  # `clock` must decorate an `i64` (via `@`) holding milliseconds since the Unix epoch.
+  [clock] > clocked
     random > @
       as-number.
         plus.
@@ -51,19 +50,12 @@
               and.
                 tbytes
                 ((one.left shift3).as-i64.minus one).as-bytes
-    (posix "gettimeofday" *).output > timeval
-    as-bytes. > tbytes
-      as-i64.
-        if.
-          os.is-windows
-          (win32 "GetSystemTime" *).milliseconds
-          plus.
-            timeval.tv-sec.times 1000
-            as-number.
-              timeval.tv-usec.as-i64.div 1000.as-i64
+    clock.as-bytes > tbytes
     35 > shift1
     17 > shift3
     00-00-00-00-00-00-00-01 > one
+  # New random with pseudo-random seed derived from the system clock.
+  clocked system-clock > pseudo
 
   # Tests that random numbers generated with the same seed are different in sequence.
   [] +> tests-random-with-seed
@@ -94,7 +86,9 @@
         (rand.next.next.lt 0).not
     (random 123).next > rand
 
-  # Tests that two pseudo-random numbers generated independently are not equal.
+  # Tests that two pseudo-random numbers seeded from distinct clocks are not equal.
   [] +> tests-two-random-numbers-not-equal
     not. > @
-      random.pseudo.eq random.pseudo
+      eq.
+        random.clocked 123.as-i64
+        random.clocked 456.as-i64

--- a/objects/ms/real.eo
+++ b/objects/ms/real.eo
@@ -1,132 +1,71 @@
-+alias ms.e
 +alias ms.pow
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
-+rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # Returns a floating point number.
 [num] > real
   num > @
 
-  # Returns the natural logarithm `e` of a `num` as `org.eolang.number`.
-  [] > ln ?
-
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow 42.5 positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-int-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow positive-infinity 42
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow positive-infinity 10.8
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-infinity-to-the-pow-of-positive-infinity-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow positive-infinity positive-infinity
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-positive-float-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow negative-infinity 9.9
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-even-positive-int-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow negative-infinity 10
       positive-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-negative-infinity-to-the-pow-of-odd-positive-int-is-positive-infinity
-    eq. +> @
+    eq. > @
       pow negative-infinity 9
       negative-infinity
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-int-is-int
-    eq. +> @
+    eq. > @
       pow 2 3
       8
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-float-to-the-pow-of-positive-int-is-float
-    eq. +> @
+    eq. > @
       pow 3.5 4
       150.0625
 
   # Tests mathematical operation functionality.
   [] +> tests-positive-int-to-the-pow-of-positive-float-is-float
-    eq. +> @
+    eq. > @
       pow 4 5
       1024
-
-  # Tests that natural logarithm of negative float returns NaN.
-  [] +> tests-ln-of-negative-float-is-nan
-    is-nan. +> @
-      ln.
-        real -2.2
-
-  # Tests that natural logarithm of zero equals negative infinity.
-  [] +> tests-ln-of-zero-is-negative-infinity
-    eq. +> @
-      ln.
-        real 0
-      negative-infinity
-
-  # Tests that natural logarithm of 1 equals zero.
-  [] +> tests-ln-of-one-is-zero
-    eq. +> @
-      ln.
-        real 1
-      0
-
-  # Tests that natural logarithm of e equals 1.
-  [] +> tests-ln-of-e-one-is-one
-    eq. +> @
-      ln.
-        real e
-      1
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-negative-int-is-nan
-    is-nan. +> @
-      ln.
-        real -42
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-int-zero-is-negative-infinity
-    eq. +> @
-      ln.
-        real 0
-      negative-infinity
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-int-one-is-zero
-    eq. +> @
-      ln.
-        real 1
-      0
-
-  # Tests mathematical operation functionality.
-  [] +> tests-ln-of-twenty
-    eq. +> @
-      ln.
-        real 20
-      2.995732273553991

--- a/objects/ms/sqrt.eo
+++ b/objects/ms/sqrt.eo
@@ -3,14 +3,14 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
 # Returns the positive square root of a `num` as `org.eolang.number`.
-[num] > sqrt ?
+[num] > sqrt /number
   # Tests that sqrt of zero is zero.
   [] +> tests-sqrt-zero
     eq. > @
@@ -43,7 +43,7 @@
 
   # Tests that square root of zero equals zero.
   [] +> tests-sqrt-check-zero-input
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -53,12 +53,12 @@
 
   # Tests that square root of negative number returns NaN.
   [] +> tests-sqrt-check-negative-input
-    is-nan. +> @
+    is-nan. > @
       sqrt -0.1
 
   # Tests that square root calculation works correctly for number input.
   [] +> tests-sqrt-check-float-input
-    lt. +> @
+    lt. > @
       abs
         real
           minus.
@@ -68,16 +68,16 @@
 
   # Tests that square root of NaN returns NaN.
   [] +> tests-sqrt-check-nan-input
-    is-nan. +> @
+    is-nan. > @
       sqrt nan
 
   # Tests that square root of positive infinity equals positive infinity.
   [] +> tests-sqrt-check-infinity-n1
-    eq. +> @
+    eq. > @
       sqrt positive-infinity
       positive-infinity
 
   # Tests that square root of negative infinity returns NaN.
   [] +> tests-sqrt-check-infinity-n2
-    is-nan. +> @
+    is-nan. > @
       sqrt negative-infinity

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -1,9 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint compound-name
 +unlint redundant-object
 
 # The `not a number` object is an abstraction
@@ -163,6 +162,12 @@
     eq. > @
       nan.as-bytes
       (0.0.div 0.0).as-bytes
+
+  # Tests that floor of NaN returns NaN.
+  [] +> tests-nan-floor-is-nan
+    eq. > @
+      nan.floor.as-bytes
+      nan.as-bytes
 
   # Tests that NaN is detected as NaN.
   nan.is-nan > [] +> nan-is-nan

--- a/objects/negative-infinity.eo
+++ b/objects/negative-infinity.eo
@@ -1,9 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint compound-name
 +unlint redundant-object
 
 # Negative infinity.
@@ -500,7 +499,7 @@
 
   # Tests that negative infinity floor equals itself.
   [] +> tests-negative-infinity-floor-is-equal-to-self
-    negative-infinity.@.eq negative-infinity > @
+    negative-infinity.floor.eq negative-infinity > @
 
   # Tests that negative infinity is not NaN.
   [] +> tests-negative-infinity-is-not-nan

--- a/objects/nk/socket.eo
+++ b/objects/nk/socket.eo
@@ -5,12 +5,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package nk
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 +unlint redundant-object
-+unlint compound-name
 
 # Socket.
 #

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -1,0 +1,29 @@
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# The `nop` object is a no-operation: it ignores its argument and
+# always behaves as TRUE. It is useful for temporarily disabling a
+# test (or any other dataizable expression) without removing the
+# code, by wrapping the original body inside `nop`:
+#
+# ```
+# [] +> works-just-fine
+#   nop > @
+#     "doesn't work for now"
+# ```
+#
+# The wrapped expression is not evaluated, and the surrounding test
+# passes trivially.
+[x] > nop
+  true > @
+
+  # Tests that nop ignores its argument and behaves as TRUE.
+  [] +> tests-nop-is-true
+    nop "anything" > @
+
+  # Tests that nop returns TRUE regardless of the argument type.
+  [] +> tests-nop-with-number-is-true
+    nop 42 > @

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -1,13 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # The `number` object is an abstraction of a 64-bit floating-point
 # number that internally is a chain of eight bytes.
@@ -28,7 +26,7 @@
         eq negative-infinity
 
   # Convert this `org.eolang.number` to `org.eolang.i64` object and return it.
-  [] > as-i64 ?
+  [] > as-i64 /i64
 
   # Returns true if this number equals `x` when compared as byte sequences.
   # The parameter `x` can be a `number` or any object convertible to `bytes`
@@ -75,7 +73,7 @@
   # Returns `org.eolang.true` if `$` > `x`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > gt ?
+  [x] > gt /true
 
   # Returns `true` if `$` >= `x`.
   # Here `x` can be a `number` or any other object which
@@ -89,12 +87,12 @@
   # Multiplication of `$` and `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > times ?
+  [x] > times /number
 
   # Sum of `$` and `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > plus ?
+  [x] > plus /number
 
   # Difference between `$` and `x`.
   # Here `x` can be a `number` or any other object which
@@ -107,12 +105,25 @@
   # Quotient of the division of `$` by `x` as `org.eolang.number`.
   # Here `x` can be a `number` or any other object which
   # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > div ?
+  [x] > div /number
 
   # The object rounds down the original `number` to the nearest
   # whole `number` that is less than or equal to it
   # and returns the result as `org.eolang.number`.
-  [] > floor ?
+  # For non-finite values (`nan`, `+inf`, `-inf`) the input is returned
+  # unchanged. For finite inputs we truncate toward zero via `as-i64`,
+  # which matches mathematical floor for every value except negative
+  # non-integers — where the truncated result is strictly greater than
+  # the original, so we subtract `1` in that single case.
+  [] > floor
+    if. > @
+      ^.is-finite.not
+      ^
+      if.
+        trunc.gt ^
+        trunc.minus 1
+        trunc
+    ^.as-i64.as-number > trunc
 
   # Tests that less-than comparison returns true when first number is smaller.
   [] +> tests-int-less-true
@@ -350,7 +361,43 @@
     eq. > @
       floor.
         13.div -5
-      -2
+      -3
+
+  # Tests that floor of a positive fractional number truncates toward zero.
+  [] +> tests-floor-positive-fraction
+    eq. > @
+      3.7.floor
+      3
+
+  # Tests that floor of a negative fractional number rounds toward negative infinity.
+  [] +> tests-floor-negative-fraction
+    eq. > @
+      -3.7.floor
+      -4
+
+  # Tests that floor of a small negative fractional number rounds toward negative infinity.
+  [] +> tests-floor-negative-small-fraction
+    eq. > @
+      -0.1.floor
+      -1
+
+  # Tests that floor of a whole number returns the same number.
+  [] +> tests-floor-of-integer
+    eq. > @
+      42.floor
+      42
+
+  # Tests that floor of a negative whole number returns the same number.
+  [] +> tests-floor-of-negative-integer
+    eq. > @
+      -5.floor
+      -5
+
+  # Tests that floor of zero returns zero.
+  [] +> tests-floor-of-zero
+    eq. > @
+      0.floor
+      0
 
   # Tests that division result can be less than one.
   [] +> tests-div-less-than-one

--- a/objects/positive-infinity.eo
+++ b/objects/positive-infinity.eo
@@ -1,9 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint compound-name
 +unlint redundant-object
 
 # Positive infinity.
@@ -513,7 +512,7 @@
 
   # Tests that positive infinity floor equals itself.
   [] +> tests-positive-infinity-floor-is-equal-to-self
-    positive-infinity.@.eq positive-infinity > @
+    positive-infinity.floor.eq positive-infinity > @
 
   # Tests that positive infinity is not NaN.
   [] +> tests-positive-infinity-is-not-nan

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/sm/getenv.eo
+++ b/objects/sm/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/sm/line-separator.eo
+++ b/objects/sm/line-separator.eo
@@ -2,11 +2,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
-+unlint compound-name
 
 # Returns the system-dependent line separator string.
 # On UNIX systems, it returns "\n";

--- a/objects/sm/os.eo
+++ b/objects/sm/os.eo
@@ -2,14 +2,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # Represents the current operating system.
 [] > os
@@ -25,7 +23,7 @@
   ((regex "/mac/i").matches name).as-bool > is-macos
 
   # Returns the name of the current operation system as `org.eolang.string`.
-  [] > name ?
+  [] > name /string
 
   # Tests that the operating system belongs to the supported OS families (Windows, macOS, or Linux).
   [] +> tests-checks-os-family

--- a/objects/sm/posix.eo
+++ b/objects/sm/posix.eo
@@ -2,14 +2,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # Makes a Unix syscall by `name` with POSIX interface.
 # Here `args` is a `org.eolang.tuple` of arguments required for
@@ -18,7 +16,7 @@
 [name args] > posix
   # Makes an actual syscall to operating system
   # Returns `org.eolang.sm.posix.return` object.
-  [] > @ ?
+  [] > @ /return
   0 > stdin-fileno
   1 > stdout-fileno
   2 > af-inet

--- a/objects/sm/system-clock.eo
+++ b/objects/sm/system-clock.eo
@@ -1,0 +1,27 @@
++alias sm.os
++alias sm.posix
++alias sm.win32
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package sm
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Wall-clock time source backed by the operating system.
+# Reads the underlying syscall: `gettimeofday` on POSIX, `GetSystemTime` on Windows.
+# Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
+[] > system-clock
+  as-i64. > @
+    if.
+      os.is-windows
+      (win32 "GetSystemTime" *).milliseconds
+      plus.
+        timeval.tv-sec.times 1000
+        as-number.
+          timeval.tv-usec.as-i64.div 1000.as-i64
+  (posix "gettimeofday" *).output > timeval
+
+  # Tests that wall-clock time is readable and positive.
+  [] +> tests-reads-positive-millis
+    system-clock.gt 0 > @

--- a/objects/sm/win32.eo
+++ b/objects/sm/win32.eo
@@ -2,15 +2,13 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint many-void-attributes
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # Makes a kernel32.dll function call by name.
 #
@@ -21,7 +19,7 @@
 [name args] > win32
   # Makes an actual function call to operating system
   # Returns `org.eolang.sm.win32.return` object.
-  [] > @ ?
+  [] > @ /return
   -10 > std-input-handle
   -11 > std-output-handle
   2 > af-inet

--- a/objects/ss/bytes-as-array.eo
+++ b/objects/ss/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/contains.eo
+++ b/objects/ss/contains.eo
@@ -1,0 +1,37 @@
++alias ss.index-of
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Returns `true` if `lst` contains `element`, `false` otherwise.
+[lst element] > contains
+  not. > @
+    eq.
+      -1
+      index-of lst element
+
+  # Tests that checking if a list contains a string works correctly.
+  [] +> tests-list-contains-string
+    contains > @
+      list
+        * "qwerty" "asdfgh" 3 "qwerty"
+      "qwerty"
+
+  # Tests that checking if a list contains a number works correctly.
+  [] +> tests-list-contains-number
+    contains > @
+      list
+        * "qwerty" "asdfgh" 3 "qwerty"
+      3
+
+  # Tests that checking if a list does not contain an element works correctly.
+  [] +> tests-list-does-not-contain
+    not. > @
+      contains
+        list
+          * "Привет" "asdfgh" 3 "qwerty"
+        "Hi"

--- a/objects/ss/eachi.eo
+++ b/objects/ss/eachi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/filtered.eo
+++ b/objects/ss/filtered.eo
@@ -1,0 +1,36 @@
++alias ss.filteredi
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Filter `lst` without index with the function `func`.
+# Here `func` must be an abstract object
+# with one attribute for the element.
+# The result of dataization the `func`
+# should be boolean, that is `true` or `false`.
+[lst func] > filtered
+  filteredi > @
+    lst
+    func item > [item index] >>
+
+  # Tests that filtering without index using greater-than comparison works correctly.
+  [] +> tests-simple-filtered
+    eq. > @
+      filtered
+        list
+          * 3 1 4 2 5
+        v.gt 2 > [v]
+      * 3 4 5
+
+  # Tests that filtering boolean values without index works correctly.
+  [] +> tests-filtered-with-bools
+    eq. > @
+      filtered
+        list
+          * true false true
+        v.not > [v]
+      * false

--- a/objects/ss/filteredi.eo
+++ b/objects/ss/filteredi.eo
@@ -1,0 +1,72 @@
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Filter `lst` with index with the function `func`.
+# Here `func` must be an abstract
+# object with two attributes. The first
+# one for the element, the second one
+# for the index. The result of dataization
+# the `func` should be boolean, that is `true` or `false`.
+[lst func] > filteredi
+  list > @
+    recfilter lst
+
+  # Recursively filters tuple elements using predicate function with index.
+  [tup] > recfilter
+    if. > @
+      tup.length.eq 0
+      *
+      if.
+        func tup.head tup.tail.length
+        next.with tup.head
+        next
+    recfilter tup.tail > next
+
+  # Tests that filtering with index using less-than comparison works correctly.
+  [] +> tests-filteredi-with-lt
+    eq. > @
+      filteredi
+        list
+          * 3 1 4 2 5
+        v.lt 3 > [v i]
+      * 1 2
+
+  # Tests that filtering with index based on string length works correctly.
+  [] +> tests-filteredi-with-string-length
+    eq. > @
+      filteredi
+        list
+          * "Hello" "Name" "EO" "List"
+        v.length.gt 4 > [v i]
+      * "Hello"
+
+  # Tests that filtering an empty list with index returns an empty list.
+  [] +> tests-filteredi-with-empty-list
+    is-empty. > @
+      filteredi
+        list
+          *
+        v.lt 3 > [v i]
+
+  # Tests that filtering elements by their index position works correctly.
+  [] +> tests-filteredi-by-index
+    eq. > @
+      filteredi
+        list
+          * 3 1 4
+        i.gt 0 > [v i]
+      * 1 4
+
+  # Tests that filtering boolean values with index works correctly.
+  [] +> tests-filteredi-with-bools
+    eq. > @
+      filteredi
+        list
+          * true false true
+        v.not > [v i]
+      * false

--- a/objects/ss/hash-code-of.eo
+++ b/objects/ss/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/index-of.eo
+++ b/objects/ss/index-of.eo
@@ -1,0 +1,63 @@
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Returns index of the first occurrence of `wanted` in `lst`.
+# If `lst` has no such element, returns -1.
+[lst wanted] > index-of
+  number > @
+    recidx lst
+
+  # Recursively searches for wanted element returning its index.
+  [tup] > recidx
+    if. > @
+      tup.length.eq 0
+      -1
+      if.
+        next.eq -1
+        if.
+          tup.head.eq wanted
+          tup.tail.length
+          -1
+        next
+    recidx tup.tail > next!
+
+  # Tests that finding the index of an element works correctly.
+  [] +> tests-returns-index-of
+    eq. > @
+      1
+      index-of
+        list
+          * 1 2 3
+        2
+
+  # Tests that finding the first index of a duplicated element works correctly.
+  [] +> tests-returns-first-index-of-element
+    eq. > @
+      0
+      index-of
+        list
+          * -1 2 -1
+        -1
+
+  # Tests that index-of returns -1 for non-existent elements.
+  [] +> tests-does-not-find-index-of
+    eq. > @
+      -1
+      index-of
+        list
+          * "qwerty" 2 3
+        7
+
+  # Tests that finding the index of a string element works correctly.
+  [] +> tests-finds-index-of-string
+    eq. > @
+      1
+      index-of
+        list
+          * "asdfgh" "qwerty" 3
+        "qwerty"

--- a/objects/ss/last-index-of.eo
+++ b/objects/ss/last-index-of.eo
@@ -1,0 +1,66 @@
++alias ss.list
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Returns index of the last occurrence of `wanted` in `lst`.
+# If `lst` has no such element, returns -1.
+[lst wanted] > last-index-of
+  reclast lst > @
+
+  # Recursively searches for last occurrence of wanted element.
+  [tup] > reclast
+    if. > @
+      tup.length.eq 0
+      -1
+      if.
+        tup.head.eq wanted
+        tup.tail.length
+        reclast tup.tail
+
+  # Tests that finding the last index of an element works correctly.
+  [] +> tests-finds-last-index-of
+    eq. > @
+      1
+      last-index-of
+        list
+          * "qwerty" 2 3
+        2
+
+  # Tests that finding the last index of a repeated element works correctly.
+  [] +> tests-finds-last-index-of-repeated
+    eq. > @
+      2
+      last-index-of
+        list
+          * 24 42 24
+        24
+
+  # Tests that last-index-of returns -1 for non-existent elements.
+  [] +> tests-last-index-of-not-found
+    eq. > @
+      -1
+      last-index-of
+        list
+          * 1 2 3
+        0
+
+  # Tests that last-index-of returns -1 for empty lists.
+  [] +> tests-last-index-of-empty
+    eq. > @
+      -1
+      last-index-of
+        list *
+        "abc"
+
+  # Tests that finding the last index of unicode strings works correctly.
+  [] +> tests-last-index-of-unicode
+    eq. > @
+      3
+      last-index-of
+        list
+          * "Hi" "Привет" "Hola" "Привет" "こんにちわ"
+        "Привет"

--- a/objects/ss/list.eo
+++ b/objects/ss/list.eo
@@ -2,10 +2,11 @@
 +alias ss.list
 +alias ss.reduced
 +alias ss.reducedi
++alias ss.withouti
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -50,18 +51,6 @@
       ^
       func item > [item index] >>
 
-  # Create a new list without the i-th element.
-  [i] > withouti
-    list > @
-      reducedi
-        ^
-        *
-        [accum item idx] >>
-          if. > @
-            i.eq idx
-            accum
-            accum.with item
-
   # Create a new list without the `element` which is `.eq` to given one.
   [element] > without
     list > @
@@ -98,79 +87,6 @@
       list passed
       ^
       accum.with item > [accum item index]
-
-  # Returns index of the first particular item in list.
-  # If the list has no this item, index-of returns -1.
-  [wanted] > index-of
-    number > @
-      recidx origin
-
-    # Recursively searches for wanted element returning its index.
-    [tup] > recidx
-      if. > @
-        tup.length.eq 0
-        -1
-        if.
-          next.eq -1
-          if.
-            tup.head.eq wanted
-            tup.tail.length
-            -1
-          next
-      recidx tup.tail > next!
-
-  # Returns index of the last particular item in list.
-  # If the list has no this item, returns -1.
-  [wanted] > last-index-of
-    reclast origin > @
-
-    # Recursively searches for last occurrence of wanted element.
-    [tup] > reclast
-      if. > @
-        tup.length.eq 0
-        -1
-        if.
-          tup.head.eq wanted
-          tup.tail.length
-          reclast tup.tail
-
-  # Returns `true` if the list contains `element`.
-  # Otherwise, `false`.
-  [element] > contains
-    not. > @
-      eq.
-        -1
-        index-of element
-
-  # Filter list with index with the function `func`.
-  # Here `func` must be an abstract
-  # object with two attributes. The first
-  # one for the element, the second one
-  # for the index. The result of dataization
-  # the `func` should be boolean, that is `true` or `false`.
-  [func] > filteredi
-    list > @
-      recfilter origin
-
-    # Recursively filters tuple elements using predicate function with index.
-    [tup] > recfilter
-      if. > @
-        tup.length.eq 0
-        *
-        if.
-          func tup.head tup.tail.length
-          next.with tup.head
-          next
-      recfilter tup.tail > next
-
-  # Filter list without index with the function `func`.
-  # Here `func` must be an abstract object
-  # with one attribute for the element.
-  # The result of dataization the `func`
-  # should be boolean, that is `true` or `false`.
-  [func] > filtered
-    filteredi > @
-      func item > [item index] >>
 
   # Get the first `index` elements from the start of the list.
   [index] > front
@@ -333,36 +249,6 @@
             ^.m.put (^.m.as-number.plus i) > [i] >>
       6
 
-  # Tests that removing an element by index works correctly.
-  [] +> tests-list-withouti
-    eq. > @
-      withouti.
-        list
-          * 1 2 3
-        1
-      * 1 3
-
-  # Tests that removing an element by index works in complex scenarios.
-  [] +> tests-list-withouti-complex-case
-    eq. > @
-      foo
-        * 1 "text" "f"
-      * "text" "f"
-    # Helper function that removes first element from given tuple.
-    [a] > foo
-      withouti. > @
-        list a
-        0
-
-  # Tests that removing an element by index works with nested arrays.
-  [] +> tests-list-withouti-nested-array
-    eq. > @
-      withouti.
-        list
-          * "smthg" 27 (* 3 2 1)
-        2
-      * "smthg" 27
-
   # Tests that removing all occurrences of a value works correctly.
   [] +> tests-list-without
     eq. > @
@@ -396,7 +282,7 @@
       eq.
         list3
         * 1 2 3
-    withouti. > list3
+    withouti > list3
       concat.
         list (* 0 1)
         list (* 2 3)
@@ -410,170 +296,6 @@
           * 0 1
         * 2 4
       * 0 1 2 4
-
-  # Tests that finding the index of an element works correctly.
-  [] +> tests-returns-index-of
-    eq. > @
-      1
-      index-of.
-        list
-          * 1 2 3
-        2
-
-  # Tests that finding the first index of a duplicated element works correctly.
-  [] +> tests-returns-first-index-of-element
-    eq. > @
-      0
-      index-of.
-        list
-          * -1 2 -1
-        -1
-
-  # Tests that index-of returns -1 for non-existent elements.
-  [] +> tests-does-not-find-index-of
-    eq. > @
-      -1
-      index-of.
-        list
-          * "qwerty" 2 3
-        7
-
-  # Tests that finding the index of a string element works correctly.
-  [] +> tests-finds-index-of-string
-    eq. > @
-      1
-      index-of.
-        list
-          * "asdfgh" "qwerty" 3
-        "qwerty"
-
-  # Tests that finding the last index of an element works correctly.
-  [] +> tests-finds-last-index-of
-    eq. > @
-      1
-      last-index-of.
-        list
-          * "qwerty" 2 3
-        2
-
-  # Tests that finding the last index of a repeated element works correctly.
-  [] +> tests-finds-last-index-of-repeated
-    eq. > @
-      2
-      last-index-of.
-        list
-          * 24 42 24
-        24
-
-  # Tests that last-index-of returns -1 for non-existent elements.
-  [] +> tests-last-index-of-not-found
-    eq. > @
-      -1
-      last-index-of.
-        list
-          * 1 2 3
-        0
-
-  # Tests that last-index-of returns -1 for empty lists.
-  [] +> tests-last-index-of-empty
-    eq. > @
-      -1
-      last-index-of.
-        list *
-        "abc"
-
-  # Tests that finding the last index of unicode strings works correctly.
-  [] +> tests-last-index-of-unicode
-    eq. > @
-      3
-      last-index-of.
-        list
-          * "Hi" "Привет" "Hola" "Привет" "こんにちわ"
-        "Привет"
-
-  # Tests that checking if a list contains a string works correctly.
-  [] +> tests-list-contains-string
-    contains. > @
-      list
-        * "qwerty" "asdfgh" 3 "qwerty"
-      "qwerty"
-
-  # Tests that checking if a list contains a number works correctly.
-  [] +> tests-list-contains-number
-    contains. > @
-      list
-        * "qwerty" "asdfgh" 3 "qwerty"
-      3
-
-  # Tests that checking if a list does not contain an element works correctly.
-  [] +> tests-list-does-not-contain
-    not. > @
-      contains.
-        list
-          * "Привет" "asdfgh" 3 "qwerty"
-        "Hi"
-
-  # Tests that filtering with index using less-than comparison works correctly.
-  [] +> tests-filteredi-with-lt
-    eq. > @
-      filteredi.
-        list
-          * 3 1 4 2 5
-        v.lt 3 > [v i]
-      * 1 2
-
-  # Tests that filtering with index based on string length works correctly.
-  [] +> tests-filteredi-with-string-length
-    eq. > @
-      filteredi.
-        list
-          * "Hello" "Name" "EO" "List"
-        v.length.gt 4 > [v i]
-      * "Hello"
-
-  # Tests that filtering an empty list with index returns an empty list.
-  [] +> tests-filteredi-with-empty-list
-    is-empty. > @
-      filteredi.
-        list
-          *
-        v.lt 3 > [v i]
-
-  # Tests that filtering elements by their index position works correctly.
-  [] +> tests-filteredi-by-index
-    eq. > @
-      filteredi.
-        list
-          * 3 1 4
-        i.gt 0 > [v i]
-      * 1 4
-
-  # Tests that filtering boolean values with index works correctly.
-  [] +> tests-filteredi-with-bools
-    eq. > @
-      filteredi.
-        list
-          * true false true
-        v.not > [v i]
-      * false
-
-  # Tests that filtering without index using greater-than comparison works correctly.
-  [] +> tests-simple-filtered
-    eq. > @
-      filtered.
-        list
-          * 3 1 4 2 5
-        v.gt 2 > [v]
-      * 3 4 5
-
-  # Tests that filtering boolean values without index works correctly.
-  [] +> tests-filtered-with-bools
-    eq. > @
-      filtered.
-        list
-          * true false true
-        v.not > [v]
-      * false
 
   # Tests that getting the first element from a list works correctly.
   [] +> tests-simple-front

--- a/objects/ss/map.eo
+++ b/objects/ss/map.eo
@@ -1,3 +1,5 @@
++alias ss.contains
++alias ss.filtered
 +alias ss.hash-code-of
 +alias ss.list
 +alias ss.mapped
@@ -5,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -32,7 +34,7 @@
         tup.length.eq 0
         couple * (list *)
         if.
-          prev.hashes.contains hash
+          contains prev.hashes hash
           prev
           couple
             prev.entries.with
@@ -114,7 +116,7 @@
       map.initialized > @
         with.
           origin.
-            filtered.
+            filtered
               list entries
               (hash.eq entry.hash).not > [entry] >>
           [] >>
@@ -128,7 +130,7 @@
     [key] > without
       map.initialized > @
         origin.
-          filtered.
+          filtered
             list entries
             (hash.eq entry.hash).not > [entry] >>
       hash-code-of key > hash!
@@ -195,39 +197,44 @@
 
   # Tests that searching for non-existent key returns false exists flag.
   [] +> tests-does-not-find-element-by-key-in-hash-map
-    map
-      *
-        map.entry "one" 1
-        map.entry "two" 2
-    .found "three"
-    .exists
-    .not > @
+    not. > @
+      exists.
+        found.
+          map
+            *
+              map.entry "one" 1
+              map.entry "two" 2
+          "three"
 
   # Tests that checking if map has an existing key returns true.
   [] +> tests-has-element-with-key-in-hash-map
-    map
-      *
-        map.entry "one" 1
-        map.entry "two" 2
-    .has "two" > @
+    has. > @
+      map
+        *
+          map.entry "one" 1
+          map.entry "two" 2
+      "two"
 
   # Tests that checking if map has non-existent key returns false.
   [] +> tests-does-not-have-element-by-key-in-hash-map
-    map
-      *
-        map.entry "one" 1
-        map.entry "two" 2
-    .has "three"
-    .not > @
+    not. > @
+      has.
+        map
+          *
+            map.entry "one" 1
+            map.entry "two" 2
+        "three"
 
   # Tests that removing non-existent key does not change the map size.
   [] +> tests-does-not-change-map-without-non-existed-element
-    map
-      *
-        map.entry "one" 1
-    .without "two"
-    .size
-    .eq 1 > @
+    eq. > @
+      size.
+        without.
+          map
+            *
+              map.entry "one" 1
+          "two"
+      1
 
   # Tests that removing an existing key from map works correctly.
   [] +> tests-removes-element-from-map-by-key

--- a/objects/ss/mapped.eo
+++ b/objects/ss/mapped.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/mappedi.eo
+++ b/objects/ss/mappedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/range-of-numbers.eo
+++ b/objects/ss/range-of-numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/range.eo
+++ b/objects/ss/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/reduced.eo
+++ b/objects/ss/reduced.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/reducedi.eo
+++ b/objects/ss/reducedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/set.eo
+++ b/objects/ss/set.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -47,18 +47,22 @@
 
   # Tests that set does not append an existing item.
   [] +> tests-does-not-append-existed-item-to-set
-    set
-      * 1 2
-    .with 1
-    .size
-    .eq 2 > @
+    eq. > @
+      size.
+        with.
+          set
+            * 1 2
+          1
+      2
 
   # Tests that set appends a new item.
   [] +> tests-appends-new-item-to-set
-    set
-      * 1 2
-    .with 3
-    .has 3 > @
+    has. > @
+      with.
+        set
+          * 1 2
+        3
+      3
 
   # Tests that empty set has size of zero.
   [] +> tests-empty-set-has-size-of-zero

--- a/objects/ss/withouti.eo
+++ b/objects/ss/withouti.eo
@@ -1,0 +1,50 @@
++alias ss.list
++alias ss.reducedi
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package ss
++version 0.61.1
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+# Create a new list without the i-th element of `lst`.
+[lst i] > withouti
+  list > @
+    reducedi
+      lst
+      *
+      [accum item idx] >>
+        if. > @
+          i.eq idx
+          accum
+          accum.with item
+
+  # Tests that removing an element by index works correctly.
+  [] +> tests-list-withouti
+    eq. > @
+      withouti
+        list
+          * 1 2 3
+        1
+      * 1 3
+
+  # Tests that removing an element by index works in complex scenarios.
+  [] +> tests-list-withouti-complex-case
+    eq. > @
+      foo
+        * 1 "text" "f"
+      * "text" "f"
+    # Helper function that removes first element from given tuple.
+    [a] > foo
+      withouti > @
+        list a
+        0
+
+  # Tests that removing an element by index works with nested arrays.
+  [] +> tests-list-withouti-nested-array
+    eq. > @
+      withouti
+        list
+          * "smthg" 27 (* 3 2 1)
+        2
+      * "smthg" 27

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -1,7 +1,7 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -428,3 +428,15 @@
       "some string"
       7
       5
+
+  # Tests that the runtime unescapes slashes in strings.
+  [] +> tests-unescapes-slashes
+    eq. > @
+      "x\\b\\f\\u\\r\\t\\n\\'"
+      78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
+
+  # Tests that the runtime unescapes symbols in strings.
+  [] +> tests-unescapes-symbols
+    eq. > @
+      "\b\f\n\r\t\u27E6"
+      08-0C-0A-0D-09-E2-9F-A6

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -1,9 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
++unlint decorated-formation
++unlint formation-without-comment
 
 # The object is a TRUE boolean state.
 [] > true
@@ -59,3 +61,149 @@
         123
         42
       123
+
+  # Tests that the runtime takes parent objects correctly.
+  [] +> tests-takes-parent-object
+    eq. > @
+      a 42
+      42
+    [x] > a
+      take > @
+      [] > take
+        ^.x > @
+
+  # Tests that the runtime takes parent through attribute access.
+  [] +> tests-takes-parent-through-attribute
+    [] > @
+      [] > @
+        [] > @
+          eq. > @
+            x
+            42
+    42 > x
+
+  # Tests that the runtime throws an error when applying to closed objects.
+  [] +> throws-when-applies-to-closed-object
+    closed true > @
+    [x] > a
+      x > @
+    a false > closed
+
+  # Tests that the runtime handles applications that call functions.
+  [] +> tests-app-that-calls-func
+    eq. > @
+      output
+      2
+    [] > app
+      f > @
+        * 1 2 3
+      [args] > f
+        2 > @
+        1 > a
+    app > output
+
+  # Tests that the runtime extracts attributes from decoratees.
+  [] +> tests-extract-attribute-from-decoratee
+    eq. > @
+      a.foo
+      43
+    [foo] > return
+    [] > a
+      ^.return > @
+        plus.
+          42
+          1
+
+  # Tests that the runtime handles deep nesting of objects.
+  [] +> tests-nesting-blah-test
+    blah0 > @
+    [] > blah0
+      blah1 > @
+      [] > blah1
+        blah2 > @
+        [] > blah2
+          blah3 > @
+          [] > blah3
+            blah4 > @
+            [] > blah4
+              blah5 > @
+              [] > blah5
+                blah6 > @
+                [] > blah6
+                  blah7 > @
+                  [] > blah7
+                    blah8 > @
+                    [] > blah8
+                      blah9 > @
+                      [] > blah9
+                        blah10 > @
+                        [] > blah10
+                          blah11 > @
+                          [] > blah11
+                            blah12 > @
+                            [] > blah12
+                              blah13 > @
+                              [] > blah13
+                                blah14 > @
+                                [] > blah14
+                                  blah15 > @
+                                  [] > blah15
+                                    blah16 > @
+                                    [] > blah16
+                                      blah17 > @
+                                      [] > blah17
+                                        blah18 > @
+                                        [] > blah18
+                                          blah19 > @
+                                          [] > blah19
+                                            blah20 > @
+                                            [] > blah20
+                                              blah21 > @
+                                              [] > blah21
+                                                blah22 > @
+                                                [] > blah22
+                                                  blah23 > @
+                                                  [] > blah23
+                                                    blah24 > @
+                                                    [] > blah24
+                                                      blah25 > @
+                                                      [] > blah25
+                                                        blah26 > @
+                                                        [] > blah26
+                                                          blah27 > @
+                                                          [] > blah27
+                                                            blah28 > @
+                                                            [] > blah28
+                                                              blah29 > @
+                                                              [] > blah29
+                                                                blah30 > @
+                                                                [] > blah30
+                                                                  blah31 > @
+                                                                  [] > blah31
+                                                                    blah32 > @
+                                                                    [] > blah32
+                                                                      blah33 > @
+                                                                      [] > blah33
+                                                                        blah34 > @
+                                                                        [] > blah34
+                                                                          blah35 > @
+                                                                          [] > blah35
+                                                                            blah36 > @
+                                                                            [] > blah36
+                                                                              blah37 > @
+                                                                              [] > blah37
+                                                                                blah38 > @
+                                                                                [] > blah38
+                                                                                  blah39 > @
+                                                                                  [] > blah39
+                                                                                    true > @
+
+  # Tests that the runtime compiles correctly with long duplicate names.
+  [] +> tests-compiles-correctly-with-long-duplicate-names
+    true > @
+    [] > long-object-name
+      [] > long-object-name
+        [] > long-object-name
+          [] > long-object-name
+            [] > long-object-name
+              42 > x

--- a/objects/try.eo
+++ b/objects/try.eo
@@ -1,11 +1,10 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # Exception handling mechanism that catches errors during dataization.
 # When `try` is dataized, it attempts to dataize the `main` attribute first.
@@ -23,7 +22,7 @@
 #   cleanup-action     # finally
 # ```
 # .
-[main catch finally] > try ?
+[main catch finally] > try /bytes
   # Tests that try-catch mechanism catches simple exceptions from string slice operations.
   [] +> tests-catches-simple-exception
     try > @

--- a/objects/tt/as-number.eo
+++ b/objects/tt/as-number.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/at.eo
+++ b/objects/tt/at.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/chained.eo
+++ b/objects/tt/chained.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-all.eo
+++ b/objects/tt/contains-all.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-any.eo
+++ b/objects/tt/contains-any.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains.eo
+++ b/objects/tt/contains.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/ends-with.eo
+++ b/objects/tt/ends-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/index-of.eo
+++ b/objects/tt/index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alpha.eo
+++ b/objects/tt/is-alpha.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alphanumeric.eo
+++ b/objects/tt/is-alphanumeric.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-ascii.eo
+++ b/objects/tt/is-ascii.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/joined.eo
+++ b/objects/tt/joined.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/last-index-of.eo
+++ b/objects/tt/last-index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/low-cased.eo
+++ b/objects/tt/low-cased.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tt/nsplit.eo
+++ b/objects/tt/nsplit.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/regex.eo
+++ b/objects/tt/regex.eo
@@ -1,14 +1,12 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
-+unlint idempotent-attribute-is-not-first
-+unlint compound-name
 
 # Regular expression in Perl format.
 # Here `expression` is a string pattern.
@@ -43,7 +41,7 @@
   # ptn2.matches "hello"                # doesn't recompile regex
   # ```
   # Returns `org.eolang.tt.regex.pattern` object.
-  [] > @ ?
+  [] > @ /pattern
 
   # Regular expression compiled into pattern.
   # Here `serialized` is `bytes` which represents serialized structure in memory
@@ -65,7 +63,7 @@
       #
       # Attention! The object is for internal usage only, please
       # don't use the object programmatically outside of `regex` object.
-      [position start] > matched-from-index ?
+      [position start] > matched-from-index /matched
 
       # Block matched the pattern.
       # Here:
@@ -241,6 +239,10 @@
   # Tests that regex compilation throws error when missing opening slash.
   [] +> throws-on-missing-first-slash-in-regex
     (regex "(.)+").compiled > @
+
+  # Tests that regex compilation throws error when missing closing slash.
+  [] +> throws-on-missing-closing-slash-in-regex
+    (regex "/pattern").compiled > @
 
   # Tests that regex with capturing groups returns correct group count and content.
   [] +> tests-regex-contains-valid-groups-on-each-matched-block

--- a/objects/tt/repeated.eo
+++ b/objects/tt/repeated.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/replaced.eo
+++ b/objects/tt/replaced.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/slice.eo
+++ b/objects/tt/slice.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/split.eo
+++ b/objects/tt/split.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/sprintf.eo
+++ b/objects/tt/sprintf.eo
@@ -1,12 +1,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # The `sprintf` object allows you to format and output text depending
 # on the arguments passed to it and return it as `org.eolang.string`.
@@ -18,7 +17,7 @@
 # - %f - converts object to `float`
 # - %x - converts object to `bytes`
 # - %b - converts object to boolean, `true` or `false`.
-[format args] > sprintf ?
+[format args] > sprintf /string
   # Tests that sprintf formats string with single %s placeholder.
   [] +> tests-prints-simple-string
     eq. > @

--- a/objects/tt/sscanf.eo
+++ b/objects/tt/sscanf.eo
@@ -3,12 +3,11 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.59.7
++rt jvm org.eolang:eo-runtime:0.61.1
 +rt node eo2js-runtime:0.0.0
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
-+unlint idempotent-attribute-is-not-first
 
 # Reads formatted input from a string.
 # This object has two free attributes:
@@ -19,7 +18,7 @@
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
-[format read] > sscanf ?
+[format read] > sscanf /tuple
   # Tests that sscanf parses string using %s format specifier.
   [] +> tests-sscanf-with-string
     eq. > @
@@ -33,6 +32,20 @@
       33
       head.
         sscanf "%d" "33"
+
+  # Tests that sscanf preserves the minus sign for negative integers.
+  [] +> tests-sscanf-with-negative-int
+    eq. > @
+      -42
+      head.
+        sscanf "%d" "-42"
+
+  # Tests that sscanf accepts an optional leading plus sign for integers.
+  [] +> tests-sscanf-with-positive-signed-int
+    eq. > @
+      42
+      head.
+        sscanf "%d" "+42"
 
   # Tests that sscanf parses floating point number using %f format specifier.
   [] +> tests-sscanf-with-float

--- a/objects/tt/starts-with.eo
+++ b/objects/tt/starts-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/string-buffer.eo
+++ b/objects/tt/string-buffer.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-left.eo
+++ b/objects/tt/trimmed-left.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-right.eo
+++ b/objects/tt/trimmed-right.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed.eo
+++ b/objects/tt/trimmed.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/up-cased.eo
+++ b/objects/tt/up-cased.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -167,10 +167,7 @@
       eq.
         arr.at 2
         3
-    *
-    .with 1
-    .with 2
-    .with 3 > arr
+    ((*.with 1).with 2).with 3 > arr
 
   # Tests that the length of an explicitly created empty tuple is zero.
   [] +> tests-gets-lengths-of-empty-tuple
@@ -219,11 +216,7 @@
       eq.
         arr.at 2
         3
-    tuple
-    .empty
-    .with 1
-    .with 2
-    .with 3 > arr
+    ((tuple.empty.with 1).with 2).with 3 > arr
 
   # Tests that using negative index -1 correctly retrieves the last element of the tuple.
   [] +> tests-tuple-with-negative-index-gets-last

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.59.7
++version 0.61.1
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
A new release `eo-0.61.1` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.