### PR TITLE
New release for eo-0.61.3

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.61.2</eo.version>
+    <eo.version>0.61.3</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bool.eo
+++ b/objects/bool.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/cti.eo
+++ b/objects/cti.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/error.eo
+++ b/objects/error.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/fs/dir.eo
+++ b/objects/fs/dir.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/file.eo
+++ b/objects/fs/file.eo
@@ -7,9 +7,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/path.eo
+++ b/objects/fs/path.eo
@@ -11,7 +11,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/fs/tmpdir.eo
+++ b/objects/fs/tmpdir.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package fs
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/go.eo
+++ b/objects/go.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -1,9 +1,9 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/io/bytes-as-input.eo
+++ b/objects/io/bytes-as-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/console.eo
+++ b/objects/io/console.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/copied.eo
+++ b/objects/io/copied.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-input.eo
+++ b/objects/io/dead-input.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/dead-output.eo
+++ b/objects/io/dead-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/input-as-bytes.eo
+++ b/objects/io/input-as-bytes.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/input-length.eo
+++ b/objects/io/input-length.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/malloc-as-output.eo
+++ b/objects/io/malloc-as-output.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/stdin.eo
+++ b/objects/io/stdin.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +unlint unit-test-missing
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT

--- a/objects/io/stdout.eo
+++ b/objects/io/stdout.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/io/tee-input.eo
+++ b/objects/io/tee-input.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package io
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/ms/abs.eo
+++ b/objects/ms/abs.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/acos.eo
+++ b/objects/ms/acos.eo
@@ -4,9 +4,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/angle.eo
+++ b/objects/ms/angle.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ms/asin.eo
+++ b/objects/ms/asin.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/e.eo
+++ b/objects/ms/e.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/exp.eo
+++ b/objects/ms/exp.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/integral.eo
+++ b/objects/ms/integral.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/ln.eo
+++ b/objects/ms/ln.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/mod.eo
+++ b/objects/ms/mod.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/numbers.eo
+++ b/objects/ms/numbers.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/pi.eo
+++ b/objects/ms/pi.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/pow.eo
+++ b/objects/ms/pow.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/random.eo
+++ b/objects/ms/random.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ms/real.eo
+++ b/objects/ms/real.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ms/sqrt.eo
+++ b/objects/ms/sqrt.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ms
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/ninf.eo
+++ b/objects/ninf.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/nk/socket.eo
+++ b/objects/nk/socket.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package nk
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
@@ -118,7 +118,11 @@
   # the original, so we subtract `1` in that single case.
   [] > floor
     if. > @
-      ^.is-finite.not
+      or.
+        ^.is-finite.not
+        or.
+          ^.gte 4503599627370496
+          ^.lte -4503599627370496
       ^
       if.
         trunc.gt ^
@@ -393,6 +397,18 @@
     eq. > @
       -5.floor
       -5
+
+  # Tests that floor of a very large positive number >= 2^52 returns itself.
+  [] +> tests-floor-of-large-positive-integer
+    eq. > @
+      100000000000000000000.floor
+      100000000000000000000
+
+  # Tests that floor of a very large negative number <= -2^52 returns itself.
+  [] +> tests-floor-of-large-negative-integer
+    eq. > @
+      -100000000000000000000.floor
+      -100000000000000000000
 
   # Tests that floor of zero returns zero.
   [] +> tests-floor-of-zero

--- a/objects/pinf.eo
+++ b/objects/pinf.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/sm/eol.eo
+++ b/objects/sm/eol.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/sm/getenv.eo
+++ b/objects/sm/getenv.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing

--- a/objects/sm/os.eo
+++ b/objects/sm/os.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/sm/posix.eo
+++ b/objects/sm/posix.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name

--- a/objects/sm/system-clock.eo
+++ b/objects/sm/system-clock.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/sm/win32.eo
+++ b/objects/sm/win32.eo
@@ -2,9 +2,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package sm
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint compound-name

--- a/objects/ss/bytes-as-array.eo
+++ b/objects/ss/bytes-as-array.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/contains.eo
+++ b/objects/ss/contains.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/eachi.eo
+++ b/objects/ss/eachi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/filtered.eo
+++ b/objects/ss/filtered.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/filteredi.eo
+++ b/objects/ss/filteredi.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/hash-code-of.eo
+++ b/objects/ss/hash-code-of.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/index-of.eo
+++ b/objects/ss/index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/last-index-of.eo
+++ b/objects/ss/last-index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/list.eo
+++ b/objects/ss/list.eo
@@ -6,7 +6,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/map.eo
+++ b/objects/ss/map.eo
@@ -7,7 +7,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/mapped.eo
+++ b/objects/ss/mapped.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/mappedi.eo
+++ b/objects/ss/mappedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/range-of-numbers.eo
+++ b/objects/ss/range-of-numbers.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/range.eo
+++ b/objects/ss/range.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/reduced.eo
+++ b/objects/ss/reduced.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/reducedi.eo
+++ b/objects/ss/reducedi.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/ss/set.eo
+++ b/objects/ss/set.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/ss/withouti.eo
+++ b/objects/ss/withouti.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package ss
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -1,7 +1,7 @@
 +alias tt.sprintf
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/try.eo
+++ b/objects/try.eo
@@ -1,8 +1,8 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package

--- a/objects/tt/as-ascii.eo
+++ b/objects/tt/as-ascii.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/as-number.eo
+++ b/objects/tt/as-number.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/at.eo
+++ b/objects/tt/at.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/chained.eo
+++ b/objects/tt/chained.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-all.eo
+++ b/objects/tt/contains-all.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains-any.eo
+++ b/objects/tt/contains-any.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/contains.eo
+++ b/objects/tt/contains.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/ends-with.eo
+++ b/objects/tt/ends-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/index-of.eo
+++ b/objects/tt/index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alpha.eo
+++ b/objects/tt/is-alpha.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-alphanumeric.eo
+++ b/objects/tt/is-alphanumeric.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-ascii.eo
+++ b/objects/tt/is-ascii.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/is-digit.eo
+++ b/objects/tt/is-digit.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/joined.eo
+++ b/objects/tt/joined.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/last-index-of.eo
+++ b/objects/tt/last-index-of.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/low-cased.eo
+++ b/objects/tt/low-cased.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tt/nsplit.eo
+++ b/objects/tt/nsplit.eo
@@ -4,7 +4,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/regex.eo
+++ b/objects/tt/regex.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tt/repeated.eo
+++ b/objects/tt/repeated.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/replaced.eo
+++ b/objects/tt/replaced.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/slice.eo
+++ b/objects/tt/slice.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/split.eo
+++ b/objects/tt/split.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/sprintf.eo
+++ b/objects/tt/sprintf.eo
@@ -1,9 +1,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/sscanf.eo
+++ b/objects/tt/sscanf.eo
@@ -3,9 +3,9 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+rt jvm org.eolang:eo-runtime:0.61.2
++rt jvm org.eolang:eo-runtime:0.61.3
 +rt node eo2js-runtime:0.0.0
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/starts-with.eo
+++ b/objects/tt/starts-with.eo
@@ -2,7 +2,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/string-buffer.eo
+++ b/objects/tt/string-buffer.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-left.eo
+++ b/objects/tt/trimmed-left.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed-right.eo
+++ b/objects/tt/trimmed-right.eo
@@ -1,7 +1,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/trimmed.eo
+++ b/objects/tt/trimmed.eo
@@ -3,7 +3,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 

--- a/objects/tt/up-cased.eo
+++ b/objects/tt/up-cased.eo
@@ -5,7 +5,7 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +package tt
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -1,6 +1,6 @@
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.2
++version 0.61.3
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package


### PR DESCRIPTION
A new release `eo-0.61.3` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.