### PR TITLE
New release for eo-0.62.0

### DIFF
--- a/make/jvm/pom.xml
+++ b/make/jvm/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>jvm</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <eo.version>0.61.3</eo.version>
+    <eo.version>0.62.0</eo.version>
     <stack-size>32M</stack-size>
     <heap-size>2G</heap-size>
   </properties>

--- a/objects/bool.eo
+++ b/objects/bool.eo
@@ -1,142 +1,134 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint decorated-formation
-+unlint formation-without-comment
-+unlint mandatory-package
-
-# A boolean value, parameterized by its choice `if`.
+# Boolean value, parameterized by its choice `if`.
 # `if` is a two-argument object that returns either its first argument
 # (for TRUE) or its second one (for FALSE). Both the byte representation
 # and every other operation are derived from this single choice, so no
 # conditional primitive is needed and `true`/`false` are simply two
 # applications of `bool`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint decorated-formation
++unlint mandatory-package
+
 [if] > bool
-  if 01- 00- > @
+  if > @
+    01-
+    00-
+  if > [x] > and
+    01-.eq x
+    false
+  if > not
+    false
+    true
+  if > [x] > or
+    true
+    01-.eq x
 
-  # Negation. TRUE becomes FALSE and FALSE becomes TRUE.
-  if false true > not
+  eq. ++> can-answer-the-left-method-of-a-chosen-branch
+    left.
+      false.if 00-00-00-00-00-00-00-09 00-00-00-00-00-00-00-05
+      1
+    00-00-00-00-00-00-00-0A
 
-  # And.
-  # A logical operation that returns true only if all given conditions are true.
-  if (01-.eq x) false > [x] > and
+  eq. ++> can-answer-the-right-method-of-a-chosen-branch
+    right.
+      true.if 00-00-00-00-00-00-00-05 00-00-00-00-00-00-00-09
+      1
+    00-00-00-00-00-00-00-02
 
-  # Or.
-  # A logical operation that returns true if at least one of the given conditions is true.
-  if true (01-.eq x) > [x] > or
-
-  # Tests that two boolean values can be compared for equality.
-  [] +> tests-compares-two-bools
-    eq. > @
-      true
-      true
-
-  # Tests that the true value can be converted to boolean representation.
-  [] +> tests-true-as-bool
-    true.as-bool > @
-
-  # Tests that boolean values cannot be equal to non-boolean types.
-  [] +> tests-compares-two-different-bool-types
-    not. > @
-      eq.
-        true
-        42
-
-  # Tests that boolean values can be compared to their byte representations.
-  [] +> tests-compares-bool-to-bytes
-    and. > @
-      true.eq 01-
-      false.eq 00-
-
-  # Tests that byte representations can be compared to boolean values.
-  [] +> tests-compares-bool-to-bytes-reverse
-    and. > @
-      01-.as-bytes.eq true
-      00-.as-bytes.eq false
-
-  # Tests that the if statement chooses the correct branch when condition is true.
-  [] +> tests-forks-on-true-condition
-    eq. > @
-      if.
-        5.eq 5
-        123
-        42
-      123
-
-  # Tests that the runtime takes parent objects correctly.
-  [] +> tests-takes-parent-object
-    eq. > @
-      a 42
-      42
-    [x] > a
-      take > @
-      [] > take
-        ^.x > @
-
-  # Tests that the runtime takes parent through attribute access.
-  [] +> tests-takes-parent-through-attribute
-    [] > @
-      [] > @
-        [] > @
-          eq. > @
-            x
-            42
-    42 > x
-
-  # Tests that the runtime throws an error when applying to closed objects.
-  [] +> throws-when-applies-to-closed-object
-    closed true > @
-    [x] > a
-      x > @
-    a false > closed
-
-  # Tests that the runtime handles applications that call functions.
-  [] +> tests-app-that-calls-func
-    eq. > @
-      output
-      2
+  ++> can-call-a-function-from-an-app
+    app.eq 2 > @
     [] > app
-      f > @
-        * 1 2 3
+      f * > @
+        1
+        2
+        3
       [args] > f
         2 > @
         1 > a
-    app > output
 
-  # Tests that the runtime extracts attributes from decoratees.
-  [] +> tests-extract-attribute-from-decoratee
-    eq. > @
-      a.foo
-      43
+  and. ++> can-compare-a-bool-to-a-string
+    true.eq "\u0001"
+    false.eq "\u0000"
+
+  and. ++> can-compare-a-bool-to-bytes
+    true.eq 01-
+    false.eq 00-
+
+  and. ++> can-compare-bytes-to-a-bool
+    01-.as-bytes.eq true
+    00-.as-bytes.eq false
+
+  true.eq true ++> can-compare-two-bools
+
+  not. ++> can-compare-two-different-bool-types
+    true.eq 42
+
+  ++> can-compile-deeply-duplicated-names
+    true > @
+    [] > long-object-name
+      [] > long-object-name
+        [] > long-object-name
+          [] > long-object-name
+            [] > long-object-name
+              42 > x
+
+  not. ++> can-conjoin-true-with-false
+    true.and false
+
+  true.as-bool ++> can-convert-true-to-a-bool
+
+  ++> can-extract-an-attribute-from-a-decoratee
+    a.foo.eq 43 > @
+    return > [] > a
+      42.plus 1
     [foo] > return
-    [] > a
-      ^.return > @
-        plus.
-          42
-          1
 
-  # Tests that the runtime handles deep nesting of objects.
-  [] +> tests-nesting-blah-test
+  eq. ++> can-fork-on-a-false-condition
+    if.
+      5.eq 8
+      123
+      42
+    42
+
+  eq. ++> can-fork-on-a-true-condition
+    if.
+      5.eq 5
+      123
+      42
+    123
+
+  true.not.eq false ++> can-negate-true
+
+  ++> can-nest-formations-that-call-each-other
     eq. > @
       blah0 0
       39
     [x] > blah0
-      blah1 (x.plus 1) > @
+      blah1 > @
+        x.plus 1
       [x] > blah1
-        blah2 (x.plus 1) > @
+        blah2 > @
+          x.plus 1
         [x] > blah2
-          blah3 (x.plus 1) > @
+          blah3 > @
+            x.plus 1
           [x] > blah3
-            blah4 (x.plus 1) > @
+            blah4 > @
+              x.plus 1
             [x] > blah4
-              blah5 (x.plus 1) > @
+              blah5 > @
+                x.plus 1
               [x] > blah5
-                blah6 (x.plus 1) > @
+                blah6 > @
+                  x.plus 1
                 [x] > blah6
-                  blah7 (x.plus 1) > @
+                  blah7 > @
+                    x.plus 1
                   [x] > blah7
                     blah8 (x.plus 1) > @
                     [x] > blah8
@@ -201,43 +193,23 @@
                                                                                 blah38 (x.plus 1) > @
                                                                                 [x] > blah38
                                                                                   blah39 (x.plus 1) > @
-                                                                                  [x] > blah39
-                                                                                    x > @
+                                                                                  x > [x] > blah39
 
-  # Tests that the runtime compiles correctly with long duplicate names.
-  [] +> tests-compiles-correctly-with-long-duplicate-names
-    true > @
-    [] > long-object-name
-      [] > long-object-name
-        [] > long-object-name
-          [] > long-object-name
-            [] > long-object-name
-              42 > x
-
-  # Tests that the negation of true equals false.
-  [] +> tests-true-not-is-false
+  ++> can-take-a-parent-object
     eq. > @
-      true.not
-      false
-
-  # Tests that boolean values can be compared to their string representations.
-  [] +> tests-compares-bool-to-string
-    and. > @
-      true.eq "\001"
-      false.eq "\000"
-
-  # Tests that logical AND of true and false equals false.
-  [] +> tests-true-and-false-is-false
-    not. > @
-      and.
-        true
-        false
-
-  # Tests that the if statement chooses the correct branch when condition is false.
-  [] +> tests-forks-on-false-condition
-    eq. > @
-      if.
-        5.eq 8
-        123
-        42
+      a 42
       42
+    [x] > a
+      take > @
+      x > [] > take
+
+  ++> can-take-a-parent-through-an-attribute
+    [] > @
+      [] > @
+        x.eq 42 > [] > @
+    42 > x
+
+  --> stops-on-applying-to-a-closed-object
+    closed true > @
+    x > [x] > a
+    a false > closed

--- a/objects/buffer.eo
+++ b/objects/buffer.eo
@@ -1,0 +1,34 @@
+# Buffer allows to sequentially build strings using `.with` object.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[buf] > buffer
+  buf > @
+  buffer > [str] > with
+    string
+      buf.as-bytes.concat str.as-bytes
+
+  eq. ++> can-build-a-simple-string
+    with.
+      with.
+        buffer "Hello"
+        ", "
+      "Jeff"
+    "Hello, Jeff"
+
+  eq. ++> can-decorate-a-string
+    buffer "Hello"
+    "Hello"
+
+  eq. ++> can-decorate-a-string-after-building
+    length.
+      with.
+        buffer
+          "Hi, "
+        "Mark"
+    8

--- a/objects/bytes.eo
+++ b/objects/bytes.eo
@@ -1,527 +1,230 @@
-+alias tt.sprintf
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
-+rt node eo2js-runtime:0.0.0
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
-
-# The object encapsulates a chain of bytes, providing bitwise operations,
-# numeric conversions, and byte manipulation methods. Objects like `number`, `string`,
-# and integer types (`i16`, `i32`, `i64`) use `bytes` as their internal representation.
+# Object `bytes` encapsulates a chain of bytes, providing the bitwise and
+# structural atoms every data object relies on. Objects like `number`, `string`,
+# and the integer types (`i16`, `i32`, `i64`) use `bytes` as their internal
+# representation, while conversions and derived operations live in the
+# `bytes` package (e.g. `bytes.as-number`, `bytes.xor`).
 #
 # Usage examples:
 # ```
 # bytes 01-02-03       # Creates a 3-byte sequence
 # FF-FF.and 00-FF      # Bitwise AND operation
-# as-bytes.as-number   # Convert 8-byte sequence to number
+# 01-02.as-number      # Convert 8-byte sequence to number
 # ```
 # .
-[data] > bytes
-  data > @
-  bytes data > as-bytes
-  eq 01- > as-bool
-  # Converts this chain of eight bytes into a number.
-  # Returns an error if the byte count is not exactly eight.
-  if. > as-number
-    eq nan.as-bytes
-    nan
-    if.
-      eq pinf.as-bytes
-      pinf
-      if.
-        eq ninf.as-bytes
-        ninf
-        if.
-          size.eq 8
-          number as-bytes
-          error
-            sprintf
-              "Can't convert non 8 length bytes to a number, bytes are %x"
-              * as-bytes
-  # Converts this chain of eight bytes into an i64 number.
-  # Returns an error if the byte count is not exactly eight.
-  if. > as-i64
-    size.eq 8
-    i64 as-bytes
-    error
-      sprintf
-        "Can't convert non 8 length bytes to i64, bytes are %x"
-        * as-bytes
-  # Converts this chain of four bytes into an i32 number.
-  # Returns an error if the byte count is not exactly four.
-  if. > as-i32
-    size.eq 4
-    i32 as-bytes
-    error
-      sprintf
-        "Can't convert non 4 length bytes to i32, bytes are %x"
-        * as-bytes
-  # Converts this chain of two bytes into an i16 number.
-  # Returns an error if the byte count is not exactly two.
-  if. > as-i16
-    size.eq 2
-    i16 as-bytes
-    error
-      sprintf
-        "Can't convert non 2 length bytes to i16, bytes are %x"
-        * as-bytes
 
-  # Returns `org.eolang.true` if current sequence of bytes equals another object.
-  # Before the actual comparison the object `b` is dataized.
-  [b] > eq /bool
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
 
-  # Returns total amount of current bytes as `org.eolang.number`.
-  [] > size /number
+[@] > bytes
+  [] > and /Q.bytes
+    ? > b /Q.bytes
+  [] > concat /Q.bytes
+    ? > b
+  [] > eq /Q.bool
+    ? > b
+  [] > not /Q.bytes
+  [] > or /Q.bytes
+    ? > b /Q.bytes
+  [] > right /Q.bytes
+    ? > x /Q.number
+  [] > size /Q.number
+  [] > slice /Q.bytes
+    ? > start /Q.number
+    ? > len /Q.number
+    ? > cant-slice /{Q.string}
 
-  # Represents a sub-sequence of `org.eolang.bytes` inside the current one.
-  [start len] > slice /bytes
+  eq. ++> can-and-negative-bytes-with-leading-zeroes
+    as-number.
+      00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00
+    0
 
-  # Calculates the bitwise AND operation and returns result as `org.eolang.bytes`.
-  [b] > and /bytes
+  eq. ++> can-and-negative-bytes-without-leading-zeroes
+    as-number.
+      00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00
+    0
 
-  # Calculates the bitwise OR operation and returns result as `org.eolang.bytes`.
-  [b] > or /bytes
+  eq. ++> can-and-one-negative-with-one-positive
+    -7.as-bytes.and 7.as-bytes
+    40-1C-00-00-00-00-00-00
 
-  # Calculates the bitwise XOR operation and returns result as `org.eolang.bytes`.
-  [b] > xor /bytes
+  eq. ++> can-and-two-negatives
+    -6.as-bytes.and -4.as-bytes
+    C0-10-00-00-00-00-00-00
 
-  # Calculates the bitwise NOT operation and returns result as `org.eolang.bytes`.
-  [] > not /bytes
+  eq. ++> can-and-two-positives
+    5.as-bytes.and 10.as-bytes
+    40-04-00-00-00-00-00-00
 
-  # Calculates the bitwise left shift.
-  right x.neg > [x] > left
+  eq. ++> can-and-two-single-byte-numbers
+    as-number.
+      1.as-bytes.and 1.as-bytes
+    1
 
-  # Calculates the bitwise right shift and returns result as `org.eolang.bytes`.
-  [x] > right /bytes
+  eq. ++> can-and-with-zero
+    0.as-bytes.and 32.as-bytes
+    00-00-00-00-00-00-00-00
 
-  # Concatenation of two byte sequences and returns result as `org.eolang.bytes`.
-  [b] > concat /bytes
+  CA-FE-BE-BE.size.eq 4 ++> can-be-written-in-several-lines
 
-  # Tests that a slice of bytes can be extracted from a larger byte sequence.
-  [] +> tests-takes-part-of-bytes
-    eq. > @
-      slice.
-        20-1F-EE-B5-90
-        1
-        3
-      1F-EE-B5
+  eq. ++> can-concat-bools-as-bytes
+    true.as-bytes.concat false.as-bytes
+    01-00
 
-  # Tests that the size of a byte slice is calculated correctly.
-  [] +> tests-size-of-part-is-correct
-    eq. > @
-      size.
-        slice.
-          20-1F-EE-B5-90-EE-BB
-          2
-          3
-      3
+  eq. ++> can-concat-bytes-with-empty-ones
+    05-5E-78.concat --
+    05-5E-78
 
-  # Tests that the byte sequence size is correctly calculated.
-  [] +> tests-counts-size-of-bytes
-    eq. > @
-      size.
-        F1-20-5F-EC-B5-90-32
-      7
+  eq. ++> can-concat-empty-bytes-with-others
+    --.concat 05-5E-78
+    05-5E-78
 
-  # Tests that bytes can be converted to string representation.
-  [] +> tests-turns-bytes-into-a-string
-    eq. > @
-      string
-        E4-BD-A0-E5-A5-BD-2C-20-D0-B4-D1-80-D1-83-D0-B3-21
-      "你好, друг!"
+  eq. ++> can-concat-strings-as-bytes
+    string
+      "hello ".as-bytes.concat
+        "world".as-bytes
+    "hello world"
 
-  # Tests the left shift operation with zero value.
-  [] +> tests-left-zero
-    not. > @
-      eq.
-        0.as-bytes.left 1
-        -1.as-bytes
+  eq. ++> can-concat-two-empty-bytes
+    --.concat --
+    --
 
-  # Tests the left shift operation with zero shift amount.
-  [] +> tests-left-with-zero
-    not. > @
-      eq.
-        2.as-bytes.left 0
-        -3.as-bytes
-
-  # Tests left shift operation with odd negative numbers.
-  [] +> tests-left-with-odd-neg
-    not. > @
-      eq.
-        -17.as-bytes.left 1
-        33.as-bytes
-
-  # Tests left shift operation with negative one value.
-  [] +> tests-left-with-minus-one
-    eq. > @
-      eq.
-        -1.as-bytes.left 3
-        7.as-bytes
-      false
-
-  # Tests left shift operation with even negative numbers.
-  # (-18.left 2).eq 71.not.
-  [] +> tests-left-with-even-neg
-    eq. > @
-      FF-FF-FF-FF-FF-FF-FF-EE.left 2
-      00-00-00-00-00-00-00-47.not
-
-  # Tests left shift operation with even positive numbers.
-  [] +> tests-left-with-even-plus
-    not. > @
-      eq.
-        4.as-bytes.left 3
-        -33.as-bytes
-
-  # Tests left shift operation with odd positive numbers.
-  [] +> tests-left-with-odd-plus
-    not. > @
-      eq.
-        5.as-bytes.left 3
-        -41.as-bytes
-
-  # Tests the right shift operation with zero value.
-  [] +> tests-right-with-zero
-    not. > @
-      eq.
-        0.as-bytes.right 2
-        -1.as-bytes
-
-  # Tests right shift operation with odd negative numbers.
-  [] +> tests-right-with-odd-neg
-    not. > @
-      eq.
-        -37.as-bytes.right 3
-        4.as-bytes
-
-  # Tests right shift operation with negative one value.
-  [] +> tests-right-with-minus-one
-    not. > @
-      eq.
-        -1.as-bytes.right 4
-        0.as-bytes
-
-  # Tests right shift operation with even negative numbers.
-  [] +> tests-right-with-even-neg
-    not. > @
-      eq.
-        -38.as-bytes.right 1
-        18.as-bytes
-
-  # Tests right shift operation with even positive numbers.
-  [] +> tests-right-with-even-plus
-    eq. > @
-      eq.
-        36.as-bytes.right 2
-        -10.as-bytes
-      false
-
-  # Tests right shift operation with odd positive numbers.
-  [] +> tests-right-with-odd-plus
-    not. > @
-      eq.
-        37.as-bytes.right 3
-        -5.as-bytes
-
-  # Tests bitwise AND operation with zero value.
-  [] +> tests-and-with-zero
-    not. > @
-      eq.
-        and.
-          0.as-bytes
-          32.as-bytes
-        -1.as-bytes
-
-  # Tests bitwise AND operation with two negative numbers.
-  [] +> tests-and-with-two-neg
-    not. > @
-      eq.
-        -6.as-bytes.and -4.as-bytes
-        7.as-bytes
-
-  # Tests bitwise AND operation with two positive numbers.
-  [] +> tests-and-with-two-plus
-    not. > @
-      eq.
-        and.
-          5.as-bytes
-          10.as-bytes
-        -1.as-bytes
-
-  # Tests bitwise AND operation with one negative and one positive number.
-  [] +> tests-and-with-one-neg-one-plus
-    not. > @
-      eq.
-        -7.as-bytes.and 7.as-bytes
-        -2.as-bytes
-
-  # Tests bitwise OR operation with zero value.
-  [] +> tests-or-with-zero
-    not. > @
-      eq.
-        -11.as-bytes.or 0.as-bytes
-        10.as-bytes
-
-  # Tests bitwise OR operation with two negative numbers.
-  [] +> tests-or-with-two-neg
-    not. > @
-      eq.
-        -27.as-bytes.or -13.as-bytes
-        8.as-bytes
-
-  # Tests bitwise OR operation with two positive numbers.
-  [] +> tests-or-with-two-plus
-    not. > @
-      eq.
-        5.as-bytes.or 14.as-bytes
-        -16.as-bytes
-
-  # Tests bitwise OR operation with one negative and one positive number.
-  [] +> tests-or-with-one-neg-one-plus
-    not. > @
-      eq.
-        -7.as-bytes.or 23.as-bytes
-        0.as-bytes
-
-  # Tests bitwise XOR operation with zero value.
-  [] +> tests-xor-with-zero
-    not. > @
-      eq.
-        0.as-bytes.xor 29.as-bytes
-        -30.as-bytes
-
-  # Tests bitwise XOR operation with two negative numbers.
-  [] +> tests-xor-with-two-neg
-    not. > @
-      eq.
-        -1.as-bytes.xor -123.as-bytes
-        -123.as-bytes
-
-  # Tests bitwise XOR operation with two positive numbers.
-  [] +> tests-xor-with-two-plus
-    not. > @
-      eq.
-        53.as-bytes.xor 24.as-bytes
-        -46.as-bytes
-
-  # Tests bitwise XOR operation with one negative and one positive number.
-  [] +> tests-xor-with-one-neg-one-plus
-    not. > @
-      eq.
-        -36.as-bytes.xor 43.as-bytes
-        8.as-bytes
-
-  # Tests bitwise NOT operation with zero value.
-  [] +> tests-not-with-zero
-    not. > @
-      eq.
-        0.as-bytes
-        0.as-bytes.not
-
-  # Tests bitwise NOT operation with negative number.
-  [] +> tests-not-with-neg
-    not. > @
-      eq.
-        -1.as-bytes
-        -1.as-bytes.not
-
-  # Tests bitwise NOT operation with positive number.
-  [] +> tests-not-with-plus
-    not. > @
-      eq.
-        53.as-bytes
-        53.as-bytes.not
-
-  # Tests the AND conjunction operation between two byte sequences.
-  [] +> tests-conjunction-of-bytes
-    eq. > @
-      a.and b
-      02-23-C0-05-5E-70-10
-    02-EF-D4-05-5E-78-3A > a
-    12-33-C1-B5-5E-71-55 > b
-
-  # Tests that bytes written across multiple lines are processed correctly.
-  [] +> tests-written-in-several-lines
-    eq. > @
-      size.
-        CA-FE-
-        BE-BE
-      4
-
-  # Tests that basic bitwise operations function correctly.
-  [] +> tests-bitwise-works
-    eq. > @
-      as-number.
-        and.
-          1.as-bytes
-          1.as-bytes
-      1
-
-  # Tests that bytes can be converted to boolean values.
-  [] +> tests-convertible-to-bool
-    not. > @
-      eq.
-        01-.as-bool
-        00-.as-bool
-
-  # Tests that bitwise operations work correctly with negative numbers.
-  # (-127.or 127).eq -1.
-  [] +> tests-bitwise-works-negative
-    eq. > @
-      as-number.
-        or.
-          FF-FF-FF-FF-FF-FF-FF-81.as-bytes
-          00-00-00-00-00-00-00-7F.as-bytes
-      FF-FF-FF-FF-FF-FF-FF-FF
-
-  # Tests that two byte sequences can be concatenated together.
-  [] +> tests-concatenation-of-bytes
+  ++> can-concat-two-long-bytes
     eq. > @
       a.concat b
       02-EF-D4-05-5E-78-3A-12-33-C1-B5-5E-71-55
     02-EF-D4-05-5E-78-3A > a
     12-33-C1-B5-5E-71-55 > b
 
-  # Tests concatenation of boolean values as byte sequences.
-  [] +> tests-concat-bools-as-bytes
+  ++> can-conjoin-two-long-bytes
     eq. > @
-      concat.
-        true.as-bytes
-        false.as-bytes
-      01-00
+      a.and b
+      02-23-C0-05-5E-70-10
+    02-EF-D4-05-5E-78-3A > a
+    12-33-C1-B5-5E-71-55 > b
 
-  # Tests concatenation of bytes with empty sequence.
-  [] +> tests-concat-with-empty
-    eq. > @
-      concat.
-        05-5E-78
-        --
-      05-5E-78
+  eq. ++> can-count-the-size-of-a-slice
+    size.
+      20-1F-EE-B5-90-EE-BB.slice 2 3
+    3
 
-  # Tests concatenation of empty sequence with bytes.
-  [] +> tests-concat-empty-with
-    eq. > @
-      concat.
-        --
-        05-5E-78
-      05-5E-78
+  F1-20-5F-EC-B5-90-32.size.eq 7 ++> can-count-the-size-of-bytes
 
-  # Tests concatenation of two empty sequences.
-  [] +> tests-concat-empty
-    eq. > @
-      concat.
-        --
-        --
-      --
+  not. ++> can-invert-negative-bytes
+    -1.as-bytes.eq -1.as-bytes.not
 
-  # Tests concatenation of string representations as bytes.
-  [] +> tests-concat-strings
-    eq. > @
-      string
-        concat.
-          "hello ".as-bytes
-          "world".as-bytes
-      "hello world"
+  not. ++> can-invert-positive-bytes
+    53.as-bytes.eq 53.as-bytes.not
 
-  # Tests that XOR operation produces correct results.
-  # (2397719729.xor 4294967295).eq 1897247566.
-  [] +> tests-xor-works
-    eq. > @
-      00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
-      00-00-00-00-71-15-B3-4E
+  not. ++> can-invert-zero-bytes
+    0.as-bytes.eq 0.as-bytes.not
 
-  # Tests XOR operation of one with itself returns zero as number.
-  [] +> tests-one-xor-one-as-number
-    eq. > @
-      (1.as-bytes.xor 1.as-bytes).as-number
-      0
+  eq. ++> can-or-negative-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
 
-  # Tests OR operation with negative bytes having leading zeros.
-  # (2397719729.or -4294967296).eq -1897247567.
-  [] +> tests-or-neg-bytes-with-leading-zeroes
-    eq. > @
-      00-00-00-00-8E-EA-4C-B1.or FF-FF-FF-FF-00-00-00-00
-      FF-FF-FF-FF-8E-EA-4C-B1
+  eq. ++> can-or-negative-bytes-with-one
+    FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
+    FF-FF-FF-FF-00-00-00-01
 
-  # Tests AND operation with negative bytes as number with leading zeros.
-  # (2397719729.and -4294967296).eq 0.
-  [] +> tests-and-neg-bytes-as-number-with-leading-zeroes
-    eq. > @
-      (00-00-00-00-8E-EA-4C-B1.and FF-FF-FF-FF-00-00-00-00).as-number
-      0
+  eq. ++> can-or-negative-bytes-with-positive-ones
+    FF-FF-FF-FF-FF-FF-FF-81.as-bytes.or 00-00-00-00-00-00-00-7F.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FF
 
-  # Tests XOR operation with negative bytes having leading zeros.
-  # (2397719729.xor -4294967296).eq -1897247567.
-  [] +> tests-xor-neg-bytes-with-leading-zeroes
-    eq. > @
-      00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
-      FF-FF-FF-FF-8E-EA-4C-B1
+  eq. ++> can-or-negative-bytes-with-zero
+    as-number.
+      -4294967296.as-bytes.or 0.as-bytes
+    -4294967296
 
-  # Tests OR operation with negative bytes without leading zeros.
-  # (4294967295.or -4294967296).eq -1.
-  [] +> tests-or-neg-bytes-without-leading-zeroes
-    eq. > @
-      00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
-      FF-FF-FF-FF-FF-FF-FF-FF
+  eq. ++> can-or-negative-bytes-without-leading-zeroes
+    00-00-00-00-FF-FF-FF-FF.or FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-FF-FF-FF-FF
 
-  # Tests AND operation with negative bytes as number without leading zeros.
-  # (4294967295.and -4294967296).eq 0.
-  [] +> tests-and-neg-bytes-as-number-without-leading-zeroes
-    eq. > @
-      (00-00-00-00-FF-FF-FF-FF.and FF-FF-FF-FF-00-00-00-00).as-number
-      0
+  eq. ++> can-or-one-negative-with-one-positive
+    -7.as-bytes.or 23.as-bytes
+    C0-3F-00-00-00-00-00-00
 
-  # Tests XOR operation with negative bytes as number without leading zeros.
-  # (4294967295.xor -4294967296).eq -1.
-  [] +> tests-xor-neg-bytes-as-number-without-leading-zeroes
-    eq. > @
-      (00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00).as-number
-      FF-FF-FF-FF-FF-FF-FF-FF
+  eq. ++> can-or-two-negatives
+    -27.as-bytes.or -13.as-bytes
+    C0-3B-00-00-00-00-00-00
 
-  # Tests OR operation of negative bytes as number with zero.
-  [] +> tests-or-neg-bytes-as-number-with-zero
-    eq. > @
-      (-4294967296.as-bytes.or 0.as-bytes).as-number
-      -4294967296
+  eq. ++> can-or-two-positives
+    5.as-bytes.or 14.as-bytes
+    40-3C-00-00-00-00-00-00
 
-  # Tests OR operation of negative bytes with one.
-  # (-4294967296L.or 1).eq -4294967295L.
-  [] +> tests-or-neg-bytes-with-one
-    eq. > @
-      FF-FF-FF-FF-00-00-00-00.or 00-00-00-00-00-00-00-01
-      FF-FF-FF-FF-00-00-00-01
+  eq. ++> can-or-with-zero
+    -11.as-bytes.or 0.as-bytes
+    C0-26-00-00-00-00-00-00
 
-  # Tests that conversion to number throws error for wrong-sized bytes.
-  [] +> throws-on-bytes-of-wrong-size-as-number
-    01-01-01-01.as-number > @
+  eq. ++> can-shift-right-an-even-negative
+    -38.as-bytes.right 1
+    60-21-80-00-00-00-00-00
 
-  # Tests that conversion to i64 throws error for wrong-sized bytes.
-  [] +> throws-on-bytes-of-wrong-size-as-i64
-    01-01-01-01.as-i64 > @
+  eq. ++> can-shift-right-an-even-positive
+    eq.
+      36.as-bytes.right 2
+      -10.as-bytes
+    false
 
-  # Tests that slicing out of bounds throws an error.
-  [] +> throws-on-out-of-bounds-slice
-    20-1F-EE-B5-90.slice 3 10 > @
+  eq. ++> can-shift-right-an-odd-negative
+    -37.as-bytes.right 3
+    18-08-50-00-00-00-00-00
 
-  # Tests that bytes can be correctly converted to i64 integer.
-  [] +> tests-bytes-converts-to-i64
-    eq. > @
-      00-00-00-00-00-00-00-2A.as-i64
-      42.as-i64
+  eq. ++> can-shift-right-an-odd-positive
+    37.as-bytes.right 3
+    08-08-50-00-00-00-00-00
 
-  # Tests that bytes converted to i64 and back remain unchanged.
-  [] +> tests-bytes-converts-to-i64-and-back
-    eq. > @
-      00-00-00-00-00-00-00-33.as-i64.as-bytes
-      00-00-00-00-00-00-00-33
+  eq. ++> can-shift-right-by-zero
+    0.as-bytes.right 2
+    00-00-00-00-00-00-00-00
 
-  # Tests that i64 bytes representation differs from number bytes representation.
-  [] +> tests-bytes-as-i64-as-bytes-not-eq-to-number-as-bytes
-    not. > @
-      eq.
-        00-00-00-00-00-00-00-2A.as-i64.as-bytes
-        42.as-bytes
+  eq. ++> can-shift-right-minus-one
+    -1.as-bytes.right 4
+    0B-FF-00-00-00-00-00-00
+
+  eq. ++> can-shift-right-the-integer-minimum
+    -1.as-bytes.right -2147483648
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-take-a-part-of-bytes
+    20-1F-EE-B5-90.slice
+      1
+      3
+    1F-EE-B5
+
+  eq. ++> can-turn-bytes-into-a-string
+    "你好, друг!"
+    "你好, друг!"
+
+  eq. ++> rejects-a-slice-whose-start-plus-length-overflows
+    "recovered"
+    20-1F-EE-B5-90.slice
+      2000000000
+      2000000000
+      "recovered" > [message]
+
+  eq. ++> rejects-an-out-of-bounds-slice
+    "recovered"
+    20-1F-EE-B5-90.slice
+      3
+      10
+      "recovered" > [message]
+
+  slice. --> stops-on-a-slice-offset-exceeding-the-int-range
+    20-1F-EE-B5-90
+    3000000000
+    1
+
+  slice. --> stops-on-an-out-of-bounds-slice
+    20-1F-EE-B5-90
+    3
+    10
+
+  20-1F.and CA-FE-BE --> stops-on-and-with-different-lengths
+
+  20-1F.or CA-FE-BE --> stops-on-or-with-different-lengths

--- a/objects/bytes/array.eo
+++ b/objects/bytes/array.eo
@@ -1,0 +1,42 @@
+# Represents sequence of bytes as array.
+# Here `b` is `bytes` objects, the return value is `tuple` where
+# each element is one `byte`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b] > array
+  size. >> len!
+    b >> data!
+  if. > [tup index] >> slice-byte
+    index.lt len
+    slice-byte
+      tup.with
+        b.slice index 1
+      as-number.
+        index.plus 1
+    tup
+  | > @
+    *
+    0
+
+  eq. ++> can-convert-bytes-to-an-array
+    array 20-1F-EE-B5-FF
+    *
+      20-
+      1F-
+      EE-
+      B5-
+      FF-
+
+  eq. ++> can-convert-a-single-byte-to-an-array
+    array 1F-
+    * 1F-
+
+  eq. ++> can-convert-zero-bytes-to-an-array
+    array --
+    *

--- a/objects/bytes/as-bool.eo
+++ b/objects/bytes/as-bool.eo
@@ -1,0 +1,14 @@
+# Bytes as a boolean: TRUE when the single byte equals `01-`, FALSE otherwise.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b] > as-bool
+  b.eq 01- > @
+
+  not. ++> can-convert-bytes-to-a-bool
+    01-.as-bool.eq 00-.as-bool

--- a/objects/bytes/as-bytes.eo
+++ b/objects/bytes/as-bytes.eo
@@ -1,0 +1,15 @@
+# Bytes as bytes: the very same chain of bytes, unchanged.
+# This identity mapping lets every data object expose its raw content
+# uniformly through `as-bytes`, with `bytes` returning itself.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b] > as-bytes
+  b > @
+
+  20-1F-EE.as-bytes.eq 20-1F-EE ++> can-return-itself

--- a/objects/bytes/as-i16.eo
+++ b/objects/bytes/as-i16.eo
@@ -1,0 +1,22 @@
+# Bytes as a signed 16-bit integer `i16`: a 2-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-i16
+  if. > @
+    b.size.eq 2
+    i16 b
+    cant-convert
+      "Can't convert non 2 length bytes to i16, bytes are %x".printf
+        * b
+
+  00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
+
+  01-01-01.as-i16 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-i32.eo
+++ b/objects/bytes/as-i32.eo
@@ -1,0 +1,22 @@
+# Bytes as a signed 32-bit integer `i32`: a 4-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-i32
+  if. > @
+    b.size.eq 4
+    i32 b
+    cant-convert
+      "Can't convert non 4 length bytes to i32, bytes are %x".printf
+        * b
+
+  00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
+
+  01-01-01-01-01.as-i32 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-i64.eo
+++ b/objects/bytes/as-i64.eo
@@ -1,0 +1,34 @@
+# Bytes as a signed 64-bit integer `i64`: an 8-byte chain reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-i64
+  if. > @
+    b.size.eq 8
+    i64 b
+    cant-convert
+      "Can't convert non 8 length bytes to i64, bytes are %x".printf
+        * b
+
+  00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> can-convert-bytes-to-i64
+
+  eq. ++> can-convert-bytes-to-i64-and-back
+    00-00-00-00-00-00-00-33.as-i64.as-bytes
+    00-00-00-00-00-00-00-33
+
+  not. ++> cannot-match-the-bytes-of-the-same-number
+    00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes
+
+  eq. ++> rejects-bytes-of-wrong-size
+    "recovered"
+    01-01-01-01.as-i64
+      "recovered" > [message]
+
+  01-01-01-01.as-i64 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-i8.eo
+++ b/objects/bytes/as-i8.eo
@@ -1,0 +1,22 @@
+# Bytes as a signed 8-bit integer `i8`: a single byte reinterpreted
+# as two's complement. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-i8
+  if. > @
+    b.size.eq 1
+    i8 b
+    cant-convert
+      "Can't convert non 1 length bytes to i8, bytes are %x".printf
+        * b
+
+  2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
+
+  01-01.as-i8 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-input.eo
+++ b/objects/bytes/as-input.eo
@@ -1,0 +1,73 @@
+# Makes an `input` from bytes.
+# Here `b` is sequence of bytes or an object that can be dataized
+# via `as-bytes`.
+# Here's how you can read portions of bytes from the input:
+# ```
+# as-input > i
+#   01-02-03-04-05-06-07-08-F5-F6
+# seq > @
+#   *
+#     i                 # error
+#     i.read 4 > i1     # 01-02-03-04
+#     i1.read 4 > i2    # 05-06-07-08
+#     i2.read 4 > i3    # F5-F6
+#     i3.read 3 > i4    # --
+# ```
+# Here every `read` object returns input block.
+# Every input block is a requested portion of bytes, so it's dataizable.
+# Also every input block has object `read` which allows to get
+# next input block with next potion of bytes.
+# If requested amount of bytes is more than amount
+# of available bytes - only available bytes are included.
+# If there's no available bytes - empty bytes (`--`) are included.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b] > as-input
+  [size] > read
+    @. > @
+      read.
+        input-block b --
+        size
+    [data buffer] > input-block
+      buffer > @
+      [size] > read
+        if. > @
+          available.eq 0
+          input-block -- --
+          input-block
+            as-bytes.
+              data.slice
+                if. >> next!
+                  gt.
+                    number available
+                    size >> requested!
+                  requested
+                  available
+                minus.
+                  number
+                    data.size >> available!
+                  number next
+            as-bytes.
+              data.slice 0 next
+
+  ++> can-make-an-input-from-bytes-and-read-it
+    and. > @
+      and.
+        and.
+          i1.eq 01-02-03-04
+          i2.eq 05-06-07-08
+        i3.eq F5-F6
+      eq.
+        i3.read 2
+        --
+    read. > i1
+      as-input 01-02-03-04-05-06-07-08-F5-F6
+      4
+    i1.read 4 > i2
+    i2.read 4 > i3

--- a/objects/bytes/as-number.eo
+++ b/objects/bytes/as-number.eo
@@ -1,0 +1,38 @@
+# Bytes as a floating-point `number`: an 8-byte chain reinterpreted as an
+# IEEE 754 double, mapping the special chains to `nan`, `pinf`, and `ninf`.
+# For any other length the `cant-convert` fallback is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-number
+  if. > @
+    b.size.eq 8
+    if.
+      is-nan.
+        number b
+      nan
+      if.
+        b.eq pinf.as-bytes
+        pinf
+        if.
+          b.eq ninf.as-bytes
+          ninf
+          number b
+    cant-convert
+      "Can't convert non 8 length bytes to a number, bytes are %x".printf
+        * b
+
+  is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
+    FF-F8-00-00-00-00-00-00.as-number
+
+  eq. ++> rejects-bytes-of-wrong-size
+    "recovered"
+    01-01-01-01.as-number
+      "recovered" > [message]
+
+  01-01-01-01.as-number --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-u16.eo
+++ b/objects/bytes/as-u16.eo
@@ -1,0 +1,22 @@
+# Bytes as an unsigned 16-bit integer `u16`: a 2-byte chain reinterpreted
+# without a sign. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-u16
+  if. > @
+    b.size.eq 2
+    u16 b
+    cant-convert
+      "Can't convert non 2 length bytes to u16, bytes are %x".printf
+        * b
+
+  00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
+
+  01-01-01.as-u16 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-u32.eo
+++ b/objects/bytes/as-u32.eo
@@ -1,0 +1,22 @@
+# Bytes as an unsigned 32-bit integer `u32`: a 4-byte chain reinterpreted
+# without a sign. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-u32
+  if. > @
+    b.size.eq 4
+    u32 b
+    cant-convert
+      "Can't convert non 4 length bytes to u32, bytes are %x".printf
+        * b
+
+  00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
+
+  01-01-01-01-01.as-u32 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-u64.eo
+++ b/objects/bytes/as-u64.eo
@@ -1,0 +1,29 @@
+# Bytes as an unsigned 64-bit integer `u64`: an 8-byte chain reinterpreted
+# without a sign. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-u64
+  if. > @
+    b.size.eq 8
+    u64 b
+    cant-convert
+      "Can't convert non 8 length bytes to u64, bytes are %x".printf
+        * b
+
+  eq. ++> can-convert-bytes-to-u64-and-back
+    00-00-00-00-00-00-00-33.as-u64.as-bytes
+    00-00-00-00-00-00-00-33
+
+  eq. ++> rejects-bytes-of-wrong-size
+    "recovered"
+    01-01-01-01.as-u64
+      "recovered" > [message]
+
+  01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/as-u8.eo
+++ b/objects/bytes/as-u8.eo
@@ -1,0 +1,22 @@
+# Bytes as an unsigned 8-bit integer `u8`: a single byte reinterpreted
+# without a sign. For any other length the `cant-convert` fallback
+# is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b cant-convert] > as-u8
+  if. > @
+    b.size.eq 1
+    u8 b
+    cant-convert
+      "Can't convert non 1 length bytes to u8, bytes are %x".printf
+        * b
+
+  2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
+
+  01-01.as-u8 --> stops-on-bytes-of-wrong-size

--- a/objects/bytes/hash.eo
+++ b/objects/bytes/hash.eo
@@ -1,0 +1,144 @@
+# Hash code - the pseudo-unique float numeric
+# representation of an object.
+#
+# Here `input` must be an object that can be converted to bytes
+# via `as-bytes` object.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[input] > hash
+  input.as-bytes >> b!
+  [acc index] >> rec-hash-code
+    if. > @
+      index.eq b.size!
+      acc.as-number
+      rec-hash-code
+        plus.
+          31.as-i64.times acc
+          as-i64.
+            00-00-00-00-00-00-00.concat
+              b.slice index 1
+        as-number.
+          index.plus 1
+  | > @
+    0
+    0
+
+  and. ++> can-hash-a-bool-into-a-number
+    eq.
+      size.
+        as-bytes.
+          hash true
+      8
+    eq.
+      size.
+        as-bytes.
+          hash false
+      8
+
+  ++> can-hash-an-integer-into-an-integer
+    1.eq > @
+      div.
+        number
+          hash 42 >> inthash!
+        number inthash
+
+  ++> can-hash-equal-numbers-alike
+    eq. > @
+      hash num
+      hash num
+    123456789012345680 > num
+
+  eq. ++> can-hash-equal-integers-alike
+    hash 42
+    hash 42
+
+  not. ++> can-hash-different-integers-apart
+    eq.
+      hash 42
+      hash 24
+
+  not. ++> can-hash-integers-of-different-signs-apart
+    eq.
+      hash 42
+      hash -42
+
+  ++> can-hash-a-string-into-an-integer
+    1.eq > @
+      div.
+        number
+          hash "hello" >> strhash!
+        number strhash
+
+  eq. ++> can-hash-equal-strings-alike
+    hash "Hello"
+    hash "Hello"
+
+  not. ++> can-hash-strings-of-the-same-length-apart
+    eq.
+      hash "one"
+      hash "two"
+
+  not. ++> can-hash-different-strings-apart
+    eq.
+      hash "hello"
+      hash "bye!!!"
+
+  ++> can-hash-an-abstract-object-into-an-integer
+    1.eq > @
+      div.
+        number
+          hash >> objhash!
+            obj 42
+        number objhash
+    x > [x] > obj
+
+  ++> can-hash-equal-abstract-objects-alike
+    eq. > @
+      hash value
+      hash value
+    x > [x] > obj
+    obj 42 > value
+
+  ++> can-hash-different-abstract-objects-apart
+    not. > @
+      eq.
+        hash
+          obj 42
+        hash
+          obj "42"
+    x > [x] > obj
+
+  ++> can-hash-a-float-into-an-integer
+    1.eq > @
+      div.
+        number
+          hash 42.42 >> flthash!
+        number flthash
+
+  ++> can-hash-equal-floats-alike
+    eq. > @
+      hash emergency
+      hash emergency
+    0.911 > emergency
+
+  ++> can-hash-equal-big-values-alike
+    eq. > @
+      hash
+        4.242e43 >> bigval!
+      hash bigval
+
+  not. ++> can-hash-different-floats-apart
+    eq.
+      hash 3.14
+      hash 2.72
+
+  not. ++> can-hash-floats-of-different-signs-apart
+    eq.
+      hash 3.22
+      hash -3.22

--- a/objects/bytes/left.eo
+++ b/objects/bytes/left.eo
@@ -1,0 +1,42 @@
+# Left bit shift of the byte chain `b` by `x` bits, expressed as a
+# right shift by the negated amount.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b x] > left
+  b.right x.neg > @
+
+  eq. ++> can-shift-left-an-even-negative
+    FF-FF-FF-FF-FF-FF-FF-EE.left 2
+    00-00-00-00-00-00-00-47.not
+
+  eq. ++> can-shift-left-an-even-positive
+    4.as-bytes.left 3
+    00-80-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-an-odd-negative
+    -17.as-bytes.left 1
+    80-62-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-an-odd-positive
+    5.as-bytes.left 3
+    00-A0-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-by-zero
+    2.as-bytes.left 0
+    40-00-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-minus-one
+    eq.
+      -1.as-bytes.left 3
+      7.as-bytes
+    false
+
+  eq. ++> can-shift-left-zero-bytes
+    0.as-bytes.left 1
+    00-00-00-00-00-00-00-00

--- a/objects/bytes/xor.eo
+++ b/objects/bytes/xor.eo
@@ -1,0 +1,49 @@
+# Bitwise exclusive OR of the byte chain `bts` with another chain `b`,
+# derived from the `and`, `or`, and `not` atoms.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package bytes
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b x] > xor
+  or. > @
+    b.and x.not
+    b.not.and x
+
+  eq. ++> can-xor-negative-bytes-with-leading-zeroes
+    00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-8E-EA-4C-B1
+
+  eq. ++> can-xor-negative-bytes-without-leading-zeroes
+    00-00-00-00-FF-FF-FF-FF.xor FF-FF-FF-FF-00-00-00-00
+    FF-FF-FF-FF-FF-FF-FF-FF
+
+  eq. ++> can-xor-one-negative-with-one-positive
+    -36.as-bytes.xor 43.as-bytes
+    80-07-80-00-00-00-00-00
+
+  eq. ++> can-xor-one-with-one
+    as-number.
+      1.as-bytes.xor 1.as-bytes
+    0
+
+  eq. ++> can-xor-two-long-bytes
+    00-00-00-00-8E-EA-4C-B1.xor 00-00-00-00-FF-FF-FF-FF
+    00-00-00-00-71-15-B3-4E
+
+  eq. ++> can-xor-two-negatives
+    -1.as-bytes.xor -123.as-bytes
+    7F-AE-C0-00-00-00-00-00
+
+  eq. ++> can-xor-two-positives
+    53.as-bytes.xor 24.as-bytes
+    00-72-80-00-00-00-00-00
+
+  eq. ++> can-xor-with-zero
+    0.as-bytes.xor 29.as-bytes
+    40-3D-00-00-00-00-00-00
+
+  20-1F.xor CA-FE-BE --> stops-on-xor-with-different-lengths

--- a/objects/chunk.eo
+++ b/objects/chunk.eo
@@ -1,0 +1,82 @@
+# Handle to a block of data allocated in heap memory.
+# It is created by `malloc.of` (and, indirectly, by `malloc.empty` and
+# `malloc.for`) and passed into the user scope, where it provides the API
+# to read and write the data of the block:
+#
+# ```
+# malloc.of
+#   8                       # allocate 8 bytes length block in memory
+#   [c]
+#     seq * > @
+#       c.write 2 "Hello"   # write object "Hello" with offset 2
+#       c.read 3 4          # read 4 bytes from offset 3 -> "ello"
+#       c.put 42            # write object 42 with offset 0
+#       c.get               # get all the data from the memory block -> 42
+#       c.size              # get size of the block
+#       c.id                # get identifier of the block
+#       c.@                 # the same as c.get
+# ```
+#
+# The `id` is the identifier the allocator gave to the block.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[id] > chunk
+  get > @
+  write > [source target length] > copy
+    target
+    read
+      source
+      length
+  read > get
+    0
+    size
+  if. > [object] > put
+    and.
+      size.gt 0
+      object.size.gt size
+    T
+      "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
+        * object.size size
+    seq *
+      write 0 object
+      get
+  [] > read /Q.bytes
+    ? > offset /Q.number
+    ? > length /Q.number
+    ? > cant-read /{Q.string}
+  [] > resized /Q.chunk
+    ? > capacity /Q.number
+  [] > size /Q.number
+  [] > write /Q.bool
+    ? > offset /Q.number
+    ? > data
+
+  eq. ++> can-get-what-was-put
+    malloc.of
+      8
+      seq * > [c]
+        c.put 42
+        c.get
+    42.as-bytes
+
+  eq. ++> can-know-its-size
+    malloc.of
+      3
+      c.size > [c]
+    3
+
+  eq. ++> can-read-a-slice-of-what-was-written
+    malloc.of
+      5
+      seq * > [c]
+        c.write 0 "hello"
+        c.read 1 3
+    "ell".as-bytes

--- a/objects/chunk/to-output.eo
+++ b/objects/chunk/to-output.eo
@@ -1,0 +1,67 @@
+# Makes an output from a `chunk` of memory. Here `allocated` is a `chunk`.
+#
+# Because this object lives in the `chunk` package, it is available on any
+# chunk as `chunk.to-output` (package extension), so there is no need to
+# reference it explicitly:
+#
+# ```
+# malloc.of > result
+#   10
+#   [mem]
+#     console.read 10 > input
+#     mem.to-output > output
+#     output.write input > @
+# ```
+#
+# After dataization, `result` holds the bytes written to the chunk.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package chunk
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[allocated] > to-output
+  [buffer] > write
+    write. > @
+      [offset] >> output-block
+        true > @
+        seq * > [buffer] > write
+          allocated.write offset buffer
+          output-block
+            offset.plus buffer.size
+      | 0
+      buffer
+
+  eq. ++> can-make-an-output-from-malloc-and-write-to-it
+    malloc.of
+      10
+      seq * > [mem]
+        write.
+          write.
+            write.
+              to-output mem
+              01-02-03
+            04-05-06-07
+          08-09-A0
+        mem
+    01-02-03-04-05-06-07-08-09-A0
+
+  eq. ++> can-make-an-output-via-a-chunk-extension
+    malloc.of
+      3
+      seq * > [mem]
+        mem.to-output.write 01-02-03
+        mem
+    01-02-03
+
+  eq. ++> can-write-data-larger-than-the-block
+    malloc.of
+      2
+      seq * > [mem]
+        write.
+          to-output mem
+          01-02-03
+        mem
+    01-02-03

--- a/objects/clock.eo
+++ b/objects/clock.eo
@@ -1,0 +1,33 @@
+# Wall-clock time source backed by the operating system.
+# Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime32_s` on Windows.
+# Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > clock
+  as-i64. > @
+    os.is-windows.if
+      plus.
+        timeb.time.times 1000
+        millitm.
+          output. >> timeb
+            win32
+              "_ftime32_s"
+              *
+      plus.
+        times.
+          seconds.
+            output. >> timeval
+              posix
+                "gettimeofday"
+                *
+          1000
+        as-number.
+          timeval.micros.as-i64.div 1000.as-i64
+
+  clock.gt 0 ++> can-read-positive-millis

--- a/objects/console.eo
+++ b/objects/console.eo
@@ -1,0 +1,130 @@
+# Basic I/O object `console` that allows to
+# interact with operation system console.
+#
+# Imagine, operation system console input is "Hello, world!"
+# Here's how you can use `console` object as input
+# ```
+# seq > @
+#   *
+#     console                # error
+#     console.read 4 > c1    # "Hell".as-bytes
+#     c1.read 4 > c2         # "o, w".as-bytes
+#     console.read 4 > c3    # "orld".as-bytes
+#     c2.read 4 > c4         # "!".as-bytes
+# ```
+#
+# Here 16 bytes are read from operation system console.
+# Every `console.read` object returns an input block.
+# Every input block is requested portion of bytes read
+# from console, so it's dataizable.
+# Also every input block has object `read` which allows to get
+# next input block with next portion of bytes read from console
+#
+# Here's how you can write to `console`.
+# ```
+# seq > @
+#   *
+#     console.write "Hello" > o1
+#     o1.write ", " > o2
+#     console.write "world!" > o3
+# ```
+#
+# Here `"Hello, world!".as-bytes` bytes are printed to console.
+# The object `write` is an output block.
+# It dataizes the given argument, converts it to string,
+# prints it to the operating system console and returns the next output block
+# ready to `write` again.
+#
+# Console operations are platform-specific, with different implementations
+# for POSIX and Windows systems. Each access to the `console` object creates
+# a new console instance, so reusing returned input/output blocks improves
+# performance by maintaining the same console session:
+#
+# Efficient (recommended):
+# ```
+# console.read 2 > i1
+# i1.read 2 > i2
+# i2.read 2 > i3
+# ```
+#
+# Less efficient (creates new console each time):
+# ```
+# console.read 2 > i1
+# console.read 2 > i2
+# console.read 2 > i3
+# ```
+#
+# Sequential reuse maintains the console state across operations.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > console
+  os.is-windows.if > @
+    [] >>
+      [size] > read
+        @. > @
+          read.
+            [buffer] >> input-block
+              buffer > @
+              [size] > read
+                seq * > @
+                  output. >> chunk!
+                    win32 *1
+                      "_read"
+                      win32.stdin
+                      size
+                  input-block chunk
+            | --
+            size
+      [buffer] > write
+        @. > @
+          write.
+            [] >> output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  win32 *1
+                    "_write"
+                    win32.stdout
+                    buffer
+                    buffer.size
+                output-block
+            buffer
+    [] >>
+      [size] > read
+        @. > @
+          read.
+            [buffer] >> input-block
+              buffer > @
+              [size] > read
+                seq * > @
+                  output. >> chunk!
+                    posix *1
+                      "read"
+                      posix.stdin
+                      size
+                  input-block chunk
+            | --
+            size
+      [buffer] > write
+        @. > @
+          write.
+            [] >> output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  posix *1
+                    "write"
+                    posix.stdout
+                    buffer
+                    buffer.size
+                output-block
+            buffer
+
+  console.write ++> can-write-to-the-console
+    "Hello, console-test!\n"

--- a/objects/dataized.eo
+++ b/objects/dataized.eo
@@ -1,11 +1,4 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-
-# The object dataizes `target`, makes a new instance of `bytes` from given
+# Object that dataizes `target`, makes a new instance of `bytes` from given
 # data and behaves as the result
 # `bytes`.
 # The object is used as implementation of caching syntax (`!`).
@@ -35,48 +28,46 @@
 # Here, when `.as-bytes` is taken, the `dataized` dataizes (takes `bytes`)
 # from the object `foo` and returns them.
 # The `.as-bytes` is used to prevent double dataization.
-[target] > dataized
-  try > @
-    target
-    error ex > [ex]
-    01-
 
-  # Tests that dataized values are not recalculated on subsequent access.
-  [] +> tests-dataized-does-not-do-recalculation
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > dataized /Q.bytes
+  ? > target
+
+  ++> can-avoid-recalculation
     eq. > @
       malloc.for
         0
         [m]
-          seq > @
-            *
-              cached.as-number
-              cached.as-bytes
-              cached.as-bool
-              m
-          # Function that increments counter in memory for testing.
-          [] > func
-            ^.m.put (^.m.as-number.plus 1) > @
-          (dataized func).as-bytes > cached
+          seq * > @
+            as-number.
+              func >> cached!
+            cached.as-bytes
+            cached.as-bool
+            m
+          m.put > [] > func
+            m.as-number.plus 1
       1
 
-  # Tests that dataized bytes behave correctly when accessed with exclamation.
-  [] +> tests-dataizes-as-bytes-behaves-as-exclamationed
-    seq > @
-      *
-        cached1
-        cached2
-        cached1
-        cached2
-        and.
-          cached1.eq cached2
-          1.eq cached1
-    # Function that increments counter in memory for testing.
+  ++> can-behave-as-a-const-when-dataized-as-bytes
+    seq * > @
+      func >> cached1!
+      func >> cached2!
+      cached1
+      cached2
+      and.
+        cached1.eq cached2
+        1.eq cached1
     malloc.for > func
       0
-      [m]
-        seq > @
-          *
-            true
-            m.put (m.as-number.plus 1)
-    (dataized func).as-bytes > cached1
-    func > cached2!
+      seq * > [m]
+        true
+        m.put
+          m.as-number.plus 1

--- a/objects/directory.eo
+++ b/objects/directory.eo
@@ -1,0 +1,76 @@
+# Directory in the file system.
+# Apparently every directory is a file.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[file] > directory
+  file > @
+  true > is-directory
+  [] > tmpfile
+    ^.exists.if > @
+      Q.file touch.as-bytes
+      T
+        "Directory %s does not exist, can't create temporary file".printf
+          * file
+    [] > touch /Q.string
+  [] > walk /Q.tuple
+    ? > glob /Q.string
+
+  ++> can-walk-recursively
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**/*.txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-plain-glob-matching-direct-children-only
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/b.txt"
+      eq.
+        length.
+          d.as-dir.walk "*.txt"
+        1
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  walk. --> stops-on-walking-an-absent-directory
+    directory mktemp.tmpfile.deleted
+    "**"
+
+  --> stops-on-walking-with-a-malformed-glob
+    d.as-dir.walk "[" > @
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted

--- a/objects/directory/deleted.eo
+++ b/objects/directory/deleted.eo
@@ -1,0 +1,51 @@
+# Recursively deletes the directory `d` and all of its contents.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d] > deleted
+  d.exists.if > @
+    seq *
+      if. > [tup] >> r
+        tup.length.eq 0
+        true
+        seq *
+          tup.head.deleted
+          r tup.tail
+      | (d.walk "**").at.^
+      d
+    d
+
+  ++> can-delete-a-directory-with-a-file-and-a-directory
+    and. > @
+      and.
+        and.
+          and.
+            inner.is-directory.and inner.exists
+            f.exists
+          dir.deleted.exists.not
+        inner.exists.not
+      f.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    dir.tmpfile > f
+    as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
+
+  ++> can-delete-a-directory-with-files-recursively
+    and. > @
+      and.
+        and.
+          first.exists.and second.exists
+          dir.deleted.exists.not
+        first.exists.not
+      second.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    dir.tmpfile > first
+    dir.tmpfile > second
+
+  not. ++> can-delete-an-empty-directory
+    exists.
+      deleted. (mktemp.tmpfile.deleted.as-path.resolved "bar-empty").as-dir.made

--- a/objects/directory/made.eo
+++ b/objects/directory/made.eo
@@ -1,0 +1,39 @@
+# Creates the directory `d`, making missing parent directories as needed.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d] > made
+  d.exists.if > @
+    d
+    seq *
+      made.
+        directory
+          file d.as-path.dirname
+      if.
+        created.code.eq 0
+        d
+        T
+          "Cant make the directory '%s': %s".printf
+            *
+              d.path
+              output.
+                called. >> created
+                  os.is-windows.if
+                    win32 *1
+                      "_mkdir"
+                      d.path
+                    posix *1
+                      "mkdir"
+                      d.path
+                      posix.permissions
+
+  ++> can-make-a-new-directory
+    dir.exists.and dir.is-directory > @
+    made. > dir
+      as-dir.
+        mktemp.tmpfile.deleted.as-path.resolved "foo-new"

--- a/objects/directory/open.eo
+++ b/objects/directory/open.eo
@@ -1,0 +1,17 @@
+# Always fails: a directory cannot be opened for I/O.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package directory
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[d mode scope] > open
+  T > @
+    "The file %s is a directory, can't open for I/O operations".printf
+      * d
+
+  mktemp.open --> stops-on-opening-a-directory
+    "w"
+    true > [x]

--- a/objects/e.eo
+++ b/objects/e.eo
@@ -1,0 +1,12 @@
+# Euler's number.
+# A fundamental mathematical constant approximately equal to 2.718281828459045.
+# When dataized, it represents the base of natural logarithms.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+2.718281828459045 > e

--- a/objects/eol.eo
+++ b/objects/eol.eo
@@ -1,0 +1,16 @@
+# Returns the system-dependent line separator string.
+# On UNIX systems, it returns "\n";
+# on Microsoft Windows systems it returns "\r\n".
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+string > eol
+  as-bytes.
+    os.is-windows.if
+      "\r\n"
+      "\n"

--- a/objects/false.eo
+++ b/objects/false.eo
@@ -1,12 +1,16 @@
+# FALSE boolean state.
+# It is the `bool` whose choice returns its second argument, so `if` picks
+# the `right` branch and the byte representation is `00-`.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The object is a FALSE boolean state.
-# It is the `bool` whose choice returns its second argument, so `if` picks
-# the `right` branch and the byte representation is `00-`.
 bool > false
-  right > [left right]
+  []
+    ? >> left
+    ? >> right
+    right > @

--- a/objects/file.eo
+++ b/objects/file.eo
@@ -1,0 +1,513 @@
+# Represents a file in the filesystem for reading and writing.
+
++alias string.contains
++alias string.joined
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[path] > file
+  path > @
+  @. > as-path
+    Q.path path
+  [] > deleted
+    exists.if > @
+      if.
+        outcome.eq 0
+        ^
+        T
+          "Cant delete the file '%s': %s".printf
+            * path removed.output
+      ^
+    removed.code > outcome
+    called. > removed
+      os.is-windows.if
+        win32 *1
+          win
+          path
+        posix *1
+          unix
+          path
+    is-directory.if > unix
+      "rmdir"
+      "unlink"
+    is-directory.if > win
+      "_rmdir"
+      "_unlink"
+  eq. > [] > exists
+    code.
+      os.is-windows.if
+        win32 *1
+          "_access"
+          path
+          0
+        posix *1
+          "access"
+          path
+          0
+    0
+  [cant-check] > is-directory
+    if. > @
+      info.code.eq 0
+      eq.
+        floor.
+          info.output.mode.div 4096
+        4
+      cant-check
+    called. > info
+      os.is-windows.if
+        win32 *1
+          "_stat64"
+          path
+        posix *1
+          "stat"
+          path
+  [target] > moved
+    if. > @
+      outcome.eq 0
+      file target
+      T
+        "Cant move the file '%s' to '%s': %s".printf
+          * path target renamed.output
+    renamed.code > outcome
+    called. > renamed
+      os.is-windows.if
+        win32 *1
+          "rename"
+          path
+          target
+        posix *1
+          "rename"
+          path
+          target
+  [mode scope cant-open] > open
+    known.not.if > @
+      T
+        "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+      if.
+        existing.and exists.not
+        cant-open
+          "File must exist for given access mod: '%s'".printf
+            *
+              mode >> access!
+        seq *
+          open-file
+          ^
+    or. > appending
+      as-bool.
+        access.eq "a"
+      as-bool.
+        access.eq "a+"
+    or. > existing
+      as-bool.
+        access.eq "r"
+      as-bool.
+        access.eq "r+"
+    or. > known
+      existing.or truncate
+      appending
+    [] > open-file
+      os.is-windows.if > @
+        open-through
+          []
+            win32 > @
+            win32 "_close" > close
+            win32 "_open" > open
+            win32 "_read" > read
+            win32 "_write" > write
+        open-through
+          []
+            posix > @
+            posix "close" > close
+            posix "open" > open
+            posix "read" > read
+            posix "write" > write
+      [syscall] > open-through
+        if. > @
+          descriptor.eq -1
+          cant-open
+            "Couldn't open file '%s': %s".printf
+              * path opened.output
+          seq *
+            scope
+              stream descriptor
+            code.
+              syscall.close
+                * descriptor
+            true
+        appending.if syscall.append 0 > append
+        existing.not.if syscall.creat 0 > creat
+        opened.code > descriptor
+        if. > direction
+          readable.and writable
+          syscall.rdwr
+          writable.if syscall.wronly syscall.rdonly
+        plus. > flags
+          plus.
+            direction.plus creat
+            trunc
+          append
+        called. > opened
+          syscall.open
+            * path flags syscall.mode
+        [descriptor] > stream
+          [size] > read
+            read. > @
+              input-block --
+              size
+            [buffer] > input-block
+              buffer > @
+              [size] > read
+                readable.not.if > @
+                  T
+                    "Can't read from file with provided access mode '%s'".printf
+                      * access
+                  seq *
+                    output. >> chunk!
+                      syscall.read
+                        * descriptor size
+                    input-block chunk
+          [buffer] > write
+            output-block.write buffer > @
+            [] > output-block
+              true > @
+              writable.not.if > [buffer] > write
+                T
+                  "Can't write to file with provided access mode '%s'".printf
+                    * access
+                seq *
+                  code.
+                    syscall.write
+                      * descriptor buffer buffer.size
+                  output-block
+        truncate.if syscall.trunc 0 > trunc
+    and. > readable
+      not.
+        as-bool.
+          access.eq "w"
+      not.
+        as-bool.
+          access.eq "a"
+    or. > truncate
+      as-bool.
+        access.eq "w"
+      as-bool.
+        access.eq "w+"
+    not. > writable
+      as-bool.
+        access.eq "r"
+  [cant-measure] > size
+    if. > @
+      info.code.eq 0
+      info.output.size
+      cant-measure
+    called. > info
+      os.is-windows.if
+        win32 *1
+          "_stat64"
+          path
+        posix *1
+          "stat"
+          path
+  [] > touched
+    exists.if > @
+      ^
+      if.
+        descriptor.eq -1
+        T
+          "Cant touch the file '%s': %s".printf
+            * path created.output
+        seq *
+          closed
+          ^
+    code. > closed
+      os.is-windows.if
+        win32 *1
+          "_close"
+          descriptor
+        posix *1
+          "close"
+          descriptor
+    called. > created
+      os.is-windows.if
+        win32 *1
+          "_creat"
+          path
+          win32.mode
+        posix *1
+          "creat"
+          path
+          posix.mode
+    created.code > descriptor
+
+  eq. ++> can-append-data-to-a-file
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        f.write "!" > [f]
+    13
+
+  mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
+
+  mktemp.tmpfile.deleted.touched.size.eq ++> can-measure-an-empty-file-after-touching
+    0
+
+  ++> can-move-a-file
+    and. > @
+      exists.
+        temp.moved
+          "%s.dest".printf
+            * temp.path
+      temp.exists.not
+    mktemp.tmpfile > temp
+
+  ++> can-read-from-a-file
+    eq. > @
+      malloc.of
+        12
+        [m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [f]
+              "r"
+              m.put > [f] >>
+                f.read 12
+            m
+      "Hello, world"
+
+  ++> can-read-from-a-file-sequentially
+    eq. > @
+      malloc.of
+        5
+        [m]
+          seq * > @
+            open.
+              mktemp.tmpfile.open
+                "w"
+                f.write "Hello, world" > [f]
+              "r"
+              m.put > [f] >>
+                read.
+                  f.read 7
+                  5
+            m
+      "world"
+
+  ++> can-read-from-a-file-through-different-instances
+    seq * > @
+      temp.open
+        "w"
+        f.write > [f]
+          "Shrek is love"
+      "Shrek is love".eq
+        malloc.of
+          13
+          [m] >>
+            seq * > @
+              open.
+                file source
+                "r"
+                m.put > [f] >>
+                  f.read 13
+              m
+    temp.path > source
+    mktemp.tmpfile > temp
+
+  ++> can-resolve-a-path-and-touch-it
+    resolved.as-dir.made.tmpfile.exists.and > @
+      string.contains
+        resolved
+        string.joined *1
+          Q.path.separator
+          "foo"
+          "bar"
+    mktemp.as-path.resolved "foo/bar" > resolved
+
+  ++> can-return-itself-after-deleting
+    temp.deleted.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  ++> can-return-itself-after-touching
+    temp.deleted.touched.path.eq temp.path > @
+    mktemp.tmpfile > temp
+
+  mktemp.tmpfile.deleted.exists.not ++> can-tell-that-a-file-is-gone-after-deleting
+
+  not. ++> can-tell-that-an-absent-file-does-not-exist
+    exists.
+      file "absent.txt"
+
+  is-directory. ++> can-tell-that-the-current-directory-is-a-directory
+    file "."
+
+  mktemp.tmpfile.deleted.touched.exists ++> can-touch-a-file
+
+  mktemp.tmpfile.deleted.touched.touched.exists ++> can-touch-a-file-twice
+
+  exists. ++> can-touch-an-absent-file-on-opening-for-appending
+    mktemp.tmpfile.deleted.open
+      "a"
+      true > [f]
+
+  exists. ++> can-touch-an-absent-file-on-opening-for-reading-or-appending
+    mktemp.tmpfile.deleted.open
+      "a+"
+      true > [f]
+
+  exists. ++> can-touch-an-absent-file-on-opening-for-writing
+    mktemp.tmpfile.deleted.open
+      "w"
+      true > [f]
+
+  exists. ++> can-touch-an-absent-file-on-opening-for-writing-or-reading
+    mktemp.tmpfile.deleted.open
+      "w+"
+      true > [f]
+
+  eq. ++> can-truncate-a-file-opened-for-writing
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "w"
+        true > [f]
+    0
+
+  eq. ++> can-truncate-a-file-opened-for-writing-or-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "w+"
+        true > [f]
+    0
+
+  eq. ++> can-write-data-to-a-file
+    size.
+      mktemp.tmpfile.open
+        "w"
+        f.write > [f]
+          "Hello, world"
+    12
+
+  eq. ++> can-write-to-a-file-sequentially
+    size.
+      mktemp.tmpfile.open
+        "a+"
+        write. > [f]
+          f.write "Hello, world"
+          "!"
+    13
+
+  ++> can-write-to-a-file-through-different-instances
+    seq * > @
+      temp.open
+        "w"
+        f.write > [f]
+          "Shrek is love"
+      open.
+        file source
+        "a"
+        f.write "!" > [f]
+      eq.
+        malloc.of
+          14
+          [m] >>
+            seq * > @
+              open.
+                file source
+                "r"
+                m.put > [f] >>
+                  f.read 14
+              m
+        "Shrek is love!"
+    temp.path > source
+    mktemp.tmpfile > temp
+
+  eq. ++> cannot-truncate-a-file-opened-for-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a"
+        true > [f]
+    12
+
+  eq. ++> cannot-truncate-a-file-opened-for-reading
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "r"
+        true > [f]
+    12
+
+  eq. ++> cannot-truncate-a-file-opened-for-reading-or-appending
+    size.
+      open.
+        mktemp.tmpfile.open
+          "w"
+          f.write "Hello, world" > [f]
+        "a+"
+        true > [f]
+    12
+
+  mktemp.tmpfile.deleted.is-directory true ++> rejects-checking-an-absent-file
+
+  eq. ++> rejects-opening-a-missing-file
+    "recovered"
+    mktemp.tmpfile.deleted.open
+      "r"
+      f > [f]
+      "recovered" > [reason]
+
+  eq. ++> rejects-sizing-an-absent-file
+    -1
+    mktemp.tmpfile.deleted.size -1
+
+  mktemp.tmpfile.deleted.is-directory --> stops-on-checking-the-directory-of-an-absent-file
+
+  seq * --> stops-on-opening-with-a-wrong-mode
+    mktemp.tmpfile.open
+      "x"
+      true > [f]
+    true
+
+  mktemp.tmpfile.open --> stops-on-reading-a-negative-size-from-a-file
+    "r"
+    f.read -5 > [f]
+
+  mktemp.tmpfile.open --> stops-on-reading-from-a-file-with-a-wrong-mode
+    "w"
+    f.read 12 > [f]
+
+  mktemp.tmpfile.deleted.open --> stops-on-reading-from-a-missing-file
+    "r"
+    f > [f]
+
+  mktemp.tmpfile.deleted.open --> stops-on-reading-or-writing-a-missing-file
+    "r+"
+    f > [f]
+
+  mktemp.tmpfile.deleted.size --> stops-on-sizing-an-absent-file
+
+  tmpfile. --> stops-on-touching-a-temp-file-in-an-absent-directory
+    @.
+      mktemp.as-path.resolved "foo"
+
+  mktemp.tmpfile.open --> stops-on-writing-with-a-wrong-mode
+    "r"
+    f.write "Hello" > [f]

--- a/objects/getenv.eo
+++ b/objects/getenv.eo
@@ -1,0 +1,21 @@
+# Get environment variable as `string`.
+# If the return `string` is empty - the variable does not exist.
+#
+# See https://man7.org/linux/man-pages/man3/getenv.3.html.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
++unlint mandatory-package
+
+output. > [name] > getenv
+  os.is-windows.if
+    win32 *1
+      "getenv"
+      name
+    posix *1
+      "getenv"
+      name

--- a/objects/i16.eo
+++ b/objects/i16.eo
@@ -1,265 +1,197 @@
-+alias tt.sprintf
+# Signed 16-bit integer.
+# Here `as-bytes` must be a `bytes` object.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
-+rt node eo2js-runtime:0.0.0
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 16 bits signed integer.
-# Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i16
   as-bytes > @
-  times -1.as-i64.as-i32.as-i16 > neg
+  [] > as-i32
+    i32 > @
+      concat.
+        if. >>
+          eq.
+            as-bytes.and 80-00
+            00-00
+          00-00
+          FF-FF
+        as-bytes
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
-
-  # Convert this `org.eolang.i16` to `org.eolang.i32` and return it.
-  # The object is an atom because it's not possible to check what
-  # bytes should be added from left so the number is valid.
-  # The different bytes should be added if number is positive and negative.
-  [] > as-i32 /i32
-
-  # Returns `org.eolang.true` if `$` < `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  as-i32.lt x.as-i16.as-i32 > [x] > lt
-
-  # Returns `org.eolang.true` if `$` <= `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  as-i32.lte x.as-i16.as-i32 > [x] > lte
-
-  # Returns `org.eolang.true` if `$` > `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  as-i32.gt x.as-i16.as-i32 > [x] > gt
-
-  # Returns `org.eolang.true` if `$` >= `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  as-i32.gte x.as-i16.as-i32 > [x] > gte
-
-  # Multiplication of `$` and `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  [x] > times
+  [x cant-divide] > div
     if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 right
-      plus.
-        i16 left
-        i16 right
-    (as-i32.times x.as-i16.as-i32).as-bytes > bts
-    bts.slice 0 2 > left
-    bts.slice 2 2 > right
-
-  # Sum of `$` and `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  [x] > plus
-    if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 right
-      plus.
-        i16 left
-        i16 right
-    (as-i32.plus x.as-i16.as-i32).as-bytes > bts
-    bts.slice 0 2 > left
-    bts.slice 2 2 > right
-
-  # Subtraction between `$` and `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  plus x.as-i16.neg > [x] > minus
-
-  # Quotient of the division of `$` by `x`.
-  # Here `x` must be an `org.eolang.i16` object.
-  # An `org.eolang.error` is returned if `x` is equal to `0`.
-  [x] > div
-    if. > @
-      xval.eq zero
-      error
-        sprintf
-          "Can't divide %d by i16 zero"
+      eq.
+        x.as-i16 >> other
+        00-00
+      cant-divide
+        "Can't divide %d by i16 zero".printf
           * as-i32.as-i64.as-number
       if.
         or.
-          left.eq zero
+          eq.
+            b.slice 0 2 >> left
+            00-00
           left.eq FF-FF
-        i16 right
+        i16
+          slice.
+            as-bytes. >> b
+              as-i32.div other.as-i32
+            2
+            2
         plus.
-          i16 left
-          i16 right
-    x.as-i16 > xval
-    (as-i32.div xval.as-i32).as-bytes > bts
-    bts.slice 0 2 > left
-    bts.slice 2 2 > right
-    00-00 > zero
+          i16
+            b.slice 0 2
+          i16
+            b.slice 2 2
+  as-i32.gt x.as-i16.as-i32 > [x] > gt
+  as-i32.gte x.as-i16.as-i32 > [x] > gte
+  as-i32.lt x.as-i16.as-i32 > [x] > lt
+  as-i32.lte x.as-i16.as-i32 > [x] > lte
+  plus x.as-i16.neg > [x] > minus
+  times -1.as-i64.as-i32.as-i16 > neg
+  [x] > plus
+    if. > @
+      or.
+        eq.
+          b.slice 0 2 >> left
+          00-00
+        left.eq FF-FF
+      i16
+        slice.
+          as-bytes. >> b
+            as-i32.plus x.as-i16.as-i32
+          2
+          2
+      plus.
+        i16
+          b.slice 0 2
+        i16
+          b.slice 2 2
+  i16 > [x] > times
+    slice.
+      as-bytes.
+        as-i32.times x.as-i16.as-i32
+      2
+      2
 
-  # Tests that i16 number has correct byte representation.
-  [] +> tests-i16-has-valid-bytes
-    eq. > @
-      42.as-i64.as-i32.as-i16.as-bytes
-      00-2A
+  eq. ++> can-add-one-to-one
+    1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
+    2.as-i64.as-i32.as-i16
 
-  # Tests that negative i16 number has correct byte representation.
-  [] +> tests-negative-i16-has-valid-bytes
-    eq. > @
-      -200.as-i64.as-i32.as-i16.as-bytes
-      FF-38
+  eq. ++> can-add-with-overflow
+    32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
+    -32768.as-i64.as-i32.as-i16
 
-  # Tests that i16 less-than comparison returns true for smaller values.
-  [] +> tests-i16-less-true
-    lt. > @
-      10.as-i64.as-i32.as-i16
-      50.as-i64.as-i32.as-i16
+  gt. ++> can-be-greater-than-a-smaller-i16
+    -200.as-i64.as-i32.as-i16
+    -1000.as-i64.as-i32.as-i16
 
-  # Tests that i16 less-than comparison returns false for equal values.
-  [] +> tests-i16-less-equal
-    not. > @
-      lt.
-        10.as-i64.as-i32.as-i16
-        10.as-i64.as-i32.as-i16
+  gte. ++> can-be-greater-than-or-equal-to-a-smaller-i16
+    -1000.as-i64.as-i32.as-i16
+    -1100.as-i64.as-i32.as-i16
 
-  # Tests that i16 less-than comparison returns false for larger values.
-  [] +> tests-i16-less-false
-    not. > @
-      lt.
-        10.as-i64.as-i32.as-i16
-        -5.as-i64.as-i32.as-i16
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-i16
+    113.as-i64.as-i32.as-i16
+    113.as-i64.as-i32.as-i16
 
-  # Tests that i16 greater-than comparison returns true for larger values.
-  [] +> tests-i16-greater-true
-    gt. > @
-      -200.as-i64.as-i32.as-i16
-      -1000.as-i64.as-i32.as-i16
+  lt. ++> can-be-less-than-a-larger-i16
+    10.as-i64.as-i32.as-i16
+    50.as-i64.as-i32.as-i16
 
-  # Tests that i16 greater-than comparison returns false for smaller values.
-  [] +> tests-i16-greater-false
-    not. > @
-      gt.
-        0.as-i64.as-i32.as-i16
-        100.as-i64.as-i32.as-i16
+  lte. ++> can-be-less-than-or-equal-to-a-larger-i16
+    -200.as-i64.as-i32.as-i16
+    -100.as-i64.as-i32.as-i16
 
-  # Tests that i16 greater-than comparison returns false for equal values.
-  [] +> tests-i16-greater-equal
-    not. > @
-      gt.
-        0.as-i64.as-i32.as-i16
-        0.as-i64.as-i32.as-i16
+  lte. ++> can-be-less-than-or-equal-to-an-equal-i16
+    50.as-i64.as-i32.as-i16
+    50.as-i64.as-i32.as-i16
 
-  # Tests that i16 less-than-or-equal comparison returns true for smaller values.
-  [] +> tests-i16-lte-true
-    lte. > @
-      -200.as-i64.as-i32.as-i16
-      -100.as-i64.as-i32.as-i16
-
-  # Tests that i16 less-than-or-equal comparison returns true for equal values.
-  [] +> tests-i16-lte-equal
-    lte. > @
-      50.as-i64.as-i32.as-i16
-      50.as-i64.as-i32.as-i16
-
-  # Tests that i16 less-than-or-equal comparison returns false for larger values.
-  [] +> tests-i16-lte-false
-    not. > @
-      lte.
-        0.as-i64.as-i32.as-i16
-        -10.as-i64.as-i32.as-i16
-
-  # Tests that i16 greater-than-or-equal comparison returns true for larger values.
-  [] +> tests-i16-gte-true
-    gte. > @
-      -1000.as-i64.as-i32.as-i16
-      -1100.as-i64.as-i32.as-i16
-
-  # Tests that i16 greater-than-or-equal comparison returns true for equal values.
-  [] +> tests-i16-gte-equal
-    gte. > @
-      113.as-i64.as-i32.as-i16
-      113.as-i64.as-i32.as-i16
-
-  # Tests that i16 greater-than-or-equal comparison returns false for smaller values.
-  [] +> tests-i16-gte-false
-    not. > @
-      gte.
-        0.as-i64.as-i32.as-i16
-        10.as-i64.as-i32.as-i16
-
-  # Tests that i16 zero equals another i16 zero.
-  [] +> tests-i16-zero-eq-to-i16-zero
-    eq. > @
-      0.as-i64.as-i32.as-i16
-      0.as-i64.as-i32.as-i16
-
-  # Tests that i16 equality comparison returns true for identical values.
-  [] +> tests-i16-eq-true
-    eq. > @
-      123.as-i64.as-i32.as-i16
-      123.as-i64.as-i32.as-i16
-
-  # Tests that i16 equality comparison returns false for different values.
-  [] +> tests-i16-eq-false
-    not. > @
-      eq.
-        123.as-i64.as-i32.as-i16
-        42.as-i64.as-i32.as-i16
-
-  # Tests that i16 addition works correctly.
-  [] +> tests-i16-one-plus-i16-one
-    eq. > @
-      1.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
-      2.as-i64.as-i32.as-i16
-
-  # Tests that i16 addition handles overflow correctly.
-  [] +> tests-i16-plus-with-overflow
-    eq. > @
-      32767.as-i64.as-i32.as-i16.plus 1.as-i64.as-i32.as-i16
-      -32768.as-i64.as-i32.as-i16
-
-  # Tests that i16 subtraction works correctly.
-  [] +> tests-i16-one-minus-i16-one
-    eq. > @
-      1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-      0.as-i64.as-i32.as-i16
-
-  # Tests that i16 subtraction handles overflow correctly.
-  [] +> tests-i16-minus-with-overflow
-    eq. > @
-      -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
-      32767.as-i64.as-i32.as-i16
-
-  # Tests that i16 division by zero throws an error.
-  2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 > [] +> throws-on-division-i16-by-i16-zero
-
-  # Tests that i16 division by one returns the original value.
-  [] +> tests-i16-div-by-i16-one
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1.as-i64.as-i32.as-i16
       dividend
     -235.as-i64.as-i32.as-i16 > dividend
 
-  # Tests that i16 division with remainder works correctly.
-  [] +> tests-i16-div-with-remainder
-    eq. > @
-      13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
-      -2.as-i64.as-i32.as-i16
+  lt. ++> can-divide-into-less-than-one
+    1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
+    1.as-i64.as-i32.as-i16
 
-  # Tests that i16 division result can be less than one.
-  [] +> tests-i16-div-less-than-i16-one
-    lt. > @
-      1.as-i64.as-i32.as-i16.div 5.as-i64.as-i32.as-i16
-      1.as-i64.as-i32.as-i16
+  eq. ++> can-divide-with-a-remainder
+    13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
+    -2.as-i64.as-i32.as-i16
 
-  # Tests that i16 multiplication by zero equals zero.
-  [] +> tests-i16-multiply-by-zero
-    eq. > @
-      1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
+  123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> can-equal-the-same-i16
+
+  0.as-i64.as-i32.as-i16.eq 0.as-i64.as-i32.as-i16 ++> can-equal-zero-to-zero
+
+  42.as-i64.as-i32.as-i16.as-bytes.eq 00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
+    -200.as-i64.as-i32.as-i16.as-bytes
+    FF-38
+
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.as-i32.as-i16.times 0.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  eq. ++> can-multiply-with-overflow
+    32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
+    -2.as-i64.as-i32.as-i16
+
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  eq. ++> can-subtract-with-overflow
+    -32768.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16
+    32767.as-i64.as-i32.as-i16
+
+  eq. ++> can-widen-a-negative-to-i32-with-sign-extension
+    -200.as-i64.as-i32.as-i16.as-i32.as-bytes
+    FF-FF-FF-38
+
+  eq. ++> can-widen-a-positive-to-i32-with-a-zero-prefix
+    42.as-i64.as-i32.as-i16.as-i32.as-bytes
+    00-00-00-2A
+
+  eq. ++> can-wrap-a-large-positive-product
+    300.as-i64.as-i32.as-i16.times 300.as-i64.as-i32.as-i16
+    24464.as-i64.as-i32.as-i16
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
+    256.as-i64.as-i32.as-i16.times 256.as-i64.as-i32.as-i16
+    0.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-a-larger-i16
+    0.as-i64.as-i32.as-i16.gt 100.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-an-equal-i16
+    0.as-i64.as-i32.as-i16.gt 0.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i16
+    0.as-i64.as-i32.as-i16.gte 10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-a-smaller-i16
+    10.as-i64.as-i32.as-i16.lt -5.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-an-equal-i16
+    10.as-i64.as-i32.as-i16.lt 10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i16
+    0.as-i64.as-i32.as-i16.lte -10.as-i64.as-i32.as-i16
+
+  not. ++> cannot-equal-a-different-i16
+    123.as-i64.as-i32.as-i16.eq 42.as-i64.as-i32.as-i16
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    2.as-i64.as-i32.as-i16.div
       0.as-i64.as-i32.as-i16
+      "recovered" > [message]
 
-  # Tests that i16 multiplication handles overflow correctly.
-  [] +> tests-i16-times-with-overflow
-    eq. > @
-      32767.as-i64.as-i32.as-i16.times 2.as-i64.as-i32.as-i16
-      -2.as-i64.as-i32.as-i16
+  2.as-i64.as-i32.as-i16.div 0.as-i64.as-i32.as-i16 --> stops-on-division-by-zero

--- a/objects/i32.eo
+++ b/objects/i32.eo
@@ -1,294 +1,220 @@
-+alias tt.sprintf
+# Signed 32-bit integer.
+# Here `as-bytes` must be a `bytes` object.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
-+rt node eo2js-runtime:0.0.0
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 32 bits signed integer.
-# Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i32
   as-bytes > @
-  times -1.as-i64.as-i32 > neg
-  as-i64.as-number > as-number
-
-  # Convert this `org.eolang.i32` to `org.eolang.i64` and return it.
-  # The object is an atom because it's not possible to check what
-  # bytes should be added from left so the number is valid.
-  # The different bytes should be added if number is positive and negative.
-  [] > as-i64 /i64
-
-  # Convert this `org.eolang.i32` to `org.eolang.i16`.
-  # The `org.eolang.error` is returned if the `org.eolang.i32` number is more than
-  # max `org.eolang.i16` value `32767`.
-  [] > as-i16
+  [cant-convert] > as-i16
     if. > @
-      or.
-        left.eq 00-00
-        left.eq FF-FF
-      i16 (as-bytes.slice 2 2)
-      error
-        sprintf
-          "Can't convert i32 number %d to i16 because it's out of i16 bounds"
+      ^.eq left.as-i32
+      left
+      cant-convert
+        "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
           * as-i64.as-number
-    (as-bytes.slice 0 2).as-bytes > left
-
-  # Returns `org.eolang.true` if `$` < `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  as-i64.lt x.as-i32.as-i64 > [x] > lt
-
-  # Returns `org.eolang.true` if `$` <= `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  as-i64.lte x.as-i32.as-i64 > [x] > lte
-
-  # Returns `org.eolang.true` if `$` > `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  as-i64.gt x.as-i32.as-i64 > [x] > gt
-
-  # Returns `org.eolang.true` if `$` >= `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  as-i64.gte x.as-i32.as-i64 > [x] > gte
-
-  # Multiplication of `$` and `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  [x] > times
+    i16 > left
+      as-bytes.slice 2 2
+  [] > as-i64
+    i64 > @
+      concat.
+        if. >>
+          eq.
+            as-bytes.and 80-00-00-00
+            00-00-00-00
+          00-00-00-00
+          FF-FF-FF-FF
+        as-bytes
+  as-i64.as-number > as-number
+  [x cant-divide] > div
     if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 right
-      plus.
-        i32 left
-        i32 right
-    (as-i64.times x.as-i32.as-i64).as-bytes > bts
-    bts.slice 0 4 > left
-    bts.slice 4 4 > right
-
-  # Sum of `$` and `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  [x] > plus
-    if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 right
-      plus.
-        i32 left
-        i32 right
-    (as-i64.plus x.as-i32.as-i64).as-bytes > bts
-    bts.slice 0 4 > left
-    bts.slice 4 4 > right
-
-  # Subtraction between `$` and `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  plus x.as-i32.neg > [x] > minus
-
-  # Quotient of the division of `$` by `x`.
-  # Here `x` must be an `org.eolang.i32` object.
-  # An `error` is returned if `x` is equal to 0.
-  [x] > div
-    if. > @
-      xval.eq zero
-      error
-        sprintf
-          "Can't divide %d by i32 zero"
+      eq.
+        x.as-i32 >> other
+        00-00-00-00
+      cant-divide
+        "Can't divide %d by i32 zero".printf
           * as-i64.as-number
       if.
         or.
-          left.eq zero
+          eq.
+            b.slice 0 4 >> left
+            00-00-00-00
           left.eq FF-FF-FF-FF
-        i32 right
+        i32
+          slice.
+            as-bytes. >> b
+              as-i64.div other.as-i64
+            4
+            4
         plus.
-          i32 left
-          i32 right
-    x.as-i32 > xval
-    (as-i64.div xval.as-i64).as-bytes > bts
-    bts.slice 0 4 > left
-    bts.slice 4 4 > right
-    00-00-00-00 > zero
+          i32
+            b.slice 0 4
+          i32
+            b.slice 4 4
+  as-i64.gt x.as-i32.as-i64 > [x] > gt
+  as-i64.gte x.as-i32.as-i64 > [x] > gte
+  as-i64.lt x.as-i32.as-i64 > [x] > lt
+  as-i64.lte x.as-i32.as-i64 > [x] > lte
+  plus x.as-i32.neg > [x] > minus
+  times -1.as-i64.as-i32 > neg
+  [x] > plus
+    if. > @
+      or.
+        eq.
+          b.slice 0 4 >> left
+          00-00-00-00
+        left.eq FF-FF-FF-FF
+      i32
+        slice.
+          as-bytes. >> b
+            as-i64.plus x.as-i32.as-i64
+          4
+          4
+      plus.
+        i32
+          b.slice 0 4
+        i32
+          b.slice 4 4
+  i32 > [x] > times
+    slice.
+      as-bytes.
+        as-i64.times x.as-i32.as-i64
+      4
+      4
 
-  # Tests that i32 number has correct byte representation.
-  [] +> tests-i32-has-valid-bytes
-    eq. > @
-      42.as-i64.as-i32.as-bytes
-      00-00-00-2A
+  eq. ++> can-add-one-to-one
+    1.as-i64.as-i32.plus 1.as-i64.as-i32
+    2.as-i64.as-i32
 
-  # Tests that negative i32 number has correct byte representation.
-  [] +> tests-negative-i32-has-valid-bytes
-    eq. > @
-      -200.as-i64.as-i32.as-bytes
-      FF-FF-FF-38
+  eq. ++> can-add-with-overflow
+    2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
+    -2147483648.as-i64.as-i32
 
-  # Tests that converting i32 to i16 and back preserves the value.
-  [] +> tests-i32-to-i16-and-back
-    eq. > @
-      123.as-i64.as-i32
-      123.as-i64.as-i32.as-i16.as-i32
+  -200.as-i64.as-i32.gt -1000.as-i64.as-i32 ++> can-be-greater-than-a-smaller-i32
 
-  # Tests that converting negative i32 to i16 and back preserves the value.
-  [] +> tests-negative-i32-to-i16-and-back
-    eq. > @
-      -123.as-i64.as-i32
-      -123.as-i64.as-i32.as-i16.as-i32
+  gte. ++> can-be-greater-than-or-equal-to-a-smaller-i32
+    -1000.as-i64.as-i32
+    -1100.as-i64.as-i32
 
-  # Tests that i32 less-than comparison returns true for smaller values.
-  [] +> tests-i32-less-true
-    lt. > @
-      10.as-i64.as-i32
-      50.as-i64.as-i32
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-i32
+    113.as-i64.as-i32
+    113.as-i64.as-i32
 
-  # Tests that i32 less-than comparison returns false for equal values.
-  [] +> tests-i32-less-equal
-    not. > @
-      lt.
-        10.as-i64.as-i32
-        10.as-i64.as-i32
+  10.as-i64.as-i32.lt 50.as-i64.as-i32 ++> can-be-less-than-a-larger-i32
 
-  # Tests that i32 less-than comparison returns false for larger values.
-  [] +> tests-i32-less-false
-    not. > @
-      lt.
-        10.as-i64.as-i32
-        -5.as-i64.as-i32
+  lte. ++> can-be-less-than-or-equal-to-a-larger-i32
+    -200.as-i64.as-i32
+    -100.as-i64.as-i32
 
-  # Tests that i32 greater-than comparison returns true for larger values.
-  [] +> tests-i32-greater-true
-    gt. > @
-      -200.as-i64.as-i32
-      -1000.as-i64.as-i32
+  lte. ++> can-be-less-than-or-equal-to-an-equal-i32
+    50.as-i64.as-i32
+    50.as-i64.as-i32
 
-  # Tests that i32 greater-than comparison returns false for smaller values.
-  [] +> tests-i32-greater-false
-    not. > @
-      gt.
-        0.as-i64.as-i32
-        100.as-i64.as-i32
+  eq. ++> can-convert-a-negative-to-i16-and-back
+    -123.as-i64.as-i32
+    -123.as-i64.as-i32.as-i16.as-i32
 
-  # Tests that i32 greater-than comparison returns false for equal values.
-  [] +> tests-i32-greater-equal
-    not. > @
-      gt.
-        0.as-i64.as-i32
-        0.as-i64.as-i32
+  eq. ++> can-convert-to-i16-and-back
+    123.as-i64.as-i32
+    123.as-i64.as-i32.as-i16.as-i32
 
-  # Tests that i32 less-than-or-equal comparison returns true for smaller values.
-  [] +> tests-i32-lte-true
-    lte. > @
-      -200.as-i64.as-i32
-      -100.as-i64.as-i32
-
-  # Tests that i32 less-than-or-equal comparison returns true for equal values.
-  [] +> tests-i32-lte-equal
-    lte. > @
-      50.as-i64.as-i32
-      50.as-i64.as-i32
-
-  # Tests that i32 less-than-or-equal comparison returns false for larger values.
-  [] +> tests-i32-lte-false
-    not. > @
-      lte.
-        0.as-i64.as-i32
-        -10.as-i64.as-i32
-
-  # Tests that i32 greater-than-or-equal comparison returns true for larger values.
-  [] +> tests-i32-gte-true
-    gte. > @
-      -1000.as-i64.as-i32
-      -1100.as-i64.as-i32
-
-  # Tests that i32 greater-than-or-equal comparison returns true for equal values.
-  [] +> tests-i32-gte-equal
-    gte. > @
-      113.as-i64.as-i32
-      113.as-i64.as-i32
-
-  # Tests that i32 greater-than-or-equal comparison returns false for smaller values.
-  [] +> tests-i32-gte-false
-    not. > @
-      gte.
-        0.as-i64.as-i32
-        10.as-i64.as-i32
-
-  # Tests that i32 zero equals another i32 zero.
-  [] +> tests-i32-zero-eq-to-i32-zero
-    eq. > @
-      0.as-i64.as-i32
-      0.as-i64.as-i32
-
-  # Tests that i32 equality comparison returns true for identical values.
-  [] +> tests-i32-eq-true
-    eq. > @
-      123.as-i64.as-i32
-      123.as-i64.as-i32
-
-  # Tests that i32 equality comparison returns false for different values.
-  [] +> tests-i32-eq-false
-    not. > @
-      eq.
-        123.as-i64.as-i32
-        42.as-i64.as-i32
-
-  # Tests that i32 addition works correctly.
-  [] +> tests-i32-one-plus-i32-one
-    eq. > @
-      1.as-i64.as-i32.plus 1.as-i64.as-i32
-      2.as-i64.as-i32
-
-  # Tests that i32 addition handles overflow correctly.
-  [] +> tests-i32-plus-with-overflow
-    eq. > @
-      2147483647.as-i64.as-i32.plus 1.as-i64.as-i32
-      -2147483648.as-i64.as-i32
-
-  # Tests that i32 subtraction works correctly.
-  [] +> tests-i32-one-minus-i32-one
-    eq. > @
-      1.as-i64.as-i32.minus 1.as-i64.as-i32
-      0.as-i64.as-i32
-
-  # Tests that i32 subtraction handles overflow correctly.
-  [] +> tests-i32-minus-with-overflow
-    eq. > @
-      -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
-      2147483647.as-i64.as-i32
-
-  # Tests that i32 division by zero throws an error.
-  2.as-i64.as-i32.div 0.as-i64.as-i32 > [] +> throws-on-division-i32-by-i32-zero
-
-  # Tests that converting i32 to i16 throws error when out of bounds.
-  247483647.as-i64.as-i32.as-i16 > [] +> throws-on-converting-to-i16-if-out-of-bounds
-
-  # Tests that i32 division by one returns the original value.
-  [] +> tests-i32-div-by-i32-one
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1.as-i64.as-i32
       dividend
     -235.as-i64.as-i32 > dividend
 
-  # Tests that i32 division with remainder works correctly.
-  [] +> tests-i32-div-with-remainder
-    eq. > @
-      13.as-i64.as-i32.div -5.as-i64.as-i32
-      -2.as-i64.as-i32
+  lt. ++> can-divide-into-less-than-one
+    1.as-i64.as-i32.div 5.as-i64.as-i32
+    1.as-i64.as-i32
 
-  # Tests that i32 division result can be less than one.
-  [] +> tests-i32-div-less-than-i32-one
-    lt. > @
-      1.as-i64.as-i32.div 5.as-i64.as-i32
-      1.as-i64.as-i32
+  eq. ++> can-divide-with-a-remainder
+    13.as-i64.as-i32.div -5.as-i64.as-i32
+    -2.as-i64.as-i32
 
-  # Tests that i32 multiplication by zero equals zero.
-  [] +> tests-i32-multiply-by-zero
-    eq. > @
-      1000.as-i64.as-i32.times 0.as-i64.as-i32
+  123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> can-equal-the-same-i32
+
+  0.as-i64.as-i32.eq 0.as-i64.as-i32 ++> can-equal-zero-to-zero
+
+  42.as-i64.as-i32.as-bytes.eq 00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
+    -200.as-i64.as-i32.as-bytes
+    FF-FF-FF-38
+
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.as-i32.times 0.as-i64.as-i32
+    0.as-i64.as-i32
+
+  eq. ++> can-multiply-with-overflow
+    2147483647.as-i64.as-i32.times 2.as-i64.as-i32
+    -2.as-i64.as-i32
+
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.as-i32.minus 1.as-i64.as-i32
+    0.as-i64.as-i32
+
+  eq. ++> can-subtract-with-overflow
+    -2147483648.as-i64.as-i32.minus 1.as-i64.as-i32
+    2147483647.as-i64.as-i32
+
+  eq. ++> can-widen-a-negative-to-i64-with-sign-extension
+    -200.as-i64.as-i32.as-i64.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-38
+
+  eq. ++> can-widen-a-positive-to-i64-with-a-zero-prefix
+    42.as-i64.as-i32.as-i64.as-bytes
+    00-00-00-00-00-00-00-2A
+
+  eq. ++> can-wrap-a-large-positive-product
+    100000.as-i64.as-i32.times 100000.as-i64.as-i32
+    1410065408.as-i64.as-i32
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
+    65536.as-i64.as-i32.times 65536.as-i64.as-i32
+    0.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-a-larger-i32
+    0.as-i64.as-i32.gt 100.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-an-equal-i32
+    0.as-i64.as-i32.gt 0.as-i64.as-i32
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i32
+    0.as-i64.as-i32.gte 10.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-a-smaller-i32
+    10.as-i64.as-i32.lt -5.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-an-equal-i32
+    10.as-i64.as-i32.lt 10.as-i64.as-i32
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i32
+    0.as-i64.as-i32.lte -10.as-i64.as-i32
+
+  not. ++> cannot-equal-a-different-i32
+    123.as-i64.as-i32.eq 42.as-i64.as-i32
+
+  eq. ++> rejects-an-out-of-bounds-conversion-to-i16
+    "recovered"
+    247483647.as-i64.as-i32.as-i16
+      "recovered" > [message]
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    2.as-i64.as-i32.div
       0.as-i64.as-i32
+      "recovered" > [message]
 
-  # Tests that i32 multiplication handles overflow correctly.
-  [] +> tests-i32-times-with-overflow
-    eq. > @
-      2147483647.as-i64.as-i32.times 2.as-i64.as-i32
-      -2.as-i64.as-i32
+  32768.as-i64.as-i32.as-i16 --> stops-on-converting-i16-max-plus-one-to-i16
+
+  -32769.as-i64.as-i32.as-i16 --> stops-on-converting-i16-min-minus-one-to-i16
+
+  247483647.as-i64.as-i32.as-i16 --> stops-on-converting-out-of-bounds-to-i16
+
+  2.as-i64.as-i32.div 0.as-i64.as-i32 --> stops-on-division-by-zero

--- a/objects/i64.eo
+++ b/objects/i64.eo
@@ -1,247 +1,332 @@
-+alias tt.sprintf
+# Signed 64-bit integer.
+# Here `as-bytes` must be a `bytes` object.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
-+rt node eo2js-runtime:0.0.0
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint mandatory-package
 
-# The 64 bits signed integer.
-# Here `as-bytes` must be a `bytes` object.
 [as-bytes] > i64
   as-bytes > @
-  times -1.as-i64 > neg
   as-i32.as-i16 > as-i16
-
-  # Convert this `org.eolang.i64` to `org.eolang.i32`.
-  # The `org.eolang.error` is returned if the `org.eolang.i64` number is more than
-  # max `org.eolang.i32` value `2147483647`.
-  [] > as-i32
+  [cant-convert] > as-i32
     if. > @
-      or.
-        left.eq 00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32 (as-bytes.slice 4 4)
-      error
-        sprintf
-          "Can't convert i64 number %d to i32 because it's out of i32 bounds"
+      ^.eq
+        as-i64.
+          i32 >> left
+            as-bytes.slice 4 4
+      left
+      cant-convert
+        "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
           * as-number
-    (as-bytes.slice 0 4).as-bytes > left
-
-  # Convert this `org.eolang.i64` to `org.eolang.number` object and return it.
-  [] > as-number /number
-
-  # Returns `org.eolang.true` if `$` < `x`.
-  # Here `x` must be an `org.eolang.i64` object.
-  [x] > lt
-    0.as-i64.gt > @
-      minus
-        i64 value
-    x > value!
-
-  # Returns `org.eolang.true` if `$` <= `x`.
-  # Here `x` must be an `org.eolang.i64` object.
-  [x] > lte
-    or. > @
-      lt value
-      ^.eq value
-    x > value!
-
-  # Returns `org.eolang.true` if `$` > `x`.
-  # Here `x` must be an `org.eolang.i64` object.
-  [x] > gt /bool
-
-  # Returns `org.eolang.true` if `$` >= `x`.
-  # Here `x` must be an `org.eolang.i64` object.
+    i32 > left
+      as-bytes.slice 4 4
+  [] > as-number
+    if. > @
+      as-bytes.eq 00-00-00-00-00-00-00-00
+      0
+      number
+        sign.or
+          exponentbits.or mantissa
+    rounded.eq 00-20-00-00-00-00-00-00 > carried
+    carried.if > exponentbits
+      as-bytes.
+        plus.
+          i64 40-00-00-00-00-00-00-00
+          i64 highestbits
+      as-bytes.
+        plus.
+          i64 3F-F0-00-00-00-00-00-00
+          i64 highestbits
+    eq. > guard
+      and.
+        magnitude.right
+          highest.minus 53
+        00-00-00-00-00-00-00-01
+      00-00-00-00-00-00-00-01
+    scanned.as-number.minus 4503599627370496 > highest
+    left. > highestbits!
+      scanned.and 00-00-00-00-00-00-00-3F
+      52
+    magnitude.right > kept!
+      highest.minus 52
+    if. > magnitude!
+      sign.eq 80-00-00-00-00-00-00-00
+      as-bytes.
+        plus.
+          i64 as-bytes.not
+          i64 00-00-00-00-00-00-00-01
+      as-bytes
+    if. > mantissa
+      highest.lte 52
+      and.
+        magnitude.left
+          52.minus highest
+        00-0F-FF-FF-FF-FF-FF-FF
+      rounded.and 00-0F-FF-FF-FF-FF-FF-FF
+    eq. > odd
+      kept.and 00-00-00-00-00-00-00-01
+      00-00-00-00-00-00-00-01
+    roundup.if > rounded!
+      as-bytes.
+        plus.
+          i64 kept
+          i64 00-00-00-00-00-00-00-01
+      kept
+    guard.and > roundup
+      sticky.or odd
+    [m acc step bit] > scan
+      if. > @
+        step.lt 1
+        acc
+        scan
+          empty.if m shifted
+          empty.if
+            acc
+            acc.or bit
+          step.div 2
+          bit.right 1
+      shifted.eq 00-00-00-00-00-00-00-00 > empty
+      m.right step > shifted!
+    scan > scanned!
+      magnitude
+      43-30-00-00-00-00-00-00
+      32
+      00-00-00-00-00-00-00-20
+    as-bytes.and 80-00-00-00-00-00-00-00 > sign!
+    not. > sticky
+      eq.
+        magnitude.left
+          117.minus highest
+        00-00-00-00-00-00-00-00
+  [x] > gt
+    if. > @
+      not.
+        eq.
+          as-bytes.and 80-00-00-00-00-00-00-00 >> sign
+          x.as-bytes.and 80-00-00-00-00-00-00-00
+      sign.eq 00-00-00-00-00-00-00-00
+      and.
+        eq.
+          and.
+            as-bytes.
+              minus x >> difference
+            80-00-00-00-00-00-00-00
+          00-00-00-00-00-00-00-00
+        not.
+          difference.as-bytes.eq 00-00-00-00-00-00-00-00
   [x] > gte
     or. > @
-      gt value
+      gt
+        x >> value!
       ^.eq value
-    x > value!
+  gt. > [x] > lt
+    i64 x.as-bytes
+    ^
+  [x] > lte
+    or. > @
+      lt
+        x >> value!
+      ^.eq value
+  plus (i64 x!).neg > [x] > minus
+  times -1.as-i64 > neg
+  [x] > plus
+    if. > [a b] >> carried
+      b.eq 00-00-00-00-00-00-00-00
+      i64 a
+      carried
+        a.xor b
+        left.
+          a.and b
+          1
+    | > @
+      as-bytes
+      x.as-bytes
+  [x] > times
+    if. > [acc a b] > looped
+      b.eq 00-00-00-00-00-00-00-00
+      i64 acc
+      looped
+        if.
+          eq.
+            b.and 00-00-00-00-00-00-00-01
+            00-00-00-00-00-00-00-01
+          as-bytes.
+            plus.
+              i64 acc
+              i64 a
+          acc
+        a.left 1
+        b.right 1
+    | > @
+      00-00-00-00-00-00-00-00
+      as-bytes
+      x.as-bytes
 
-  # Multiplication of `$` and `x` as `org.eolang.i64`.
-  # Here `x` must be an `org.eolang.i64` object.
-  [x] > times /i64
+  eq. ++> can-add-mixed-signs
+    -100.as-i64.plus 42.as-i64
+    -58.as-i64
 
-  # Sum of `$` and `x` as `org.eolang.i64`.
-  # Here `x` must be an `org.eolang.i64` object.
-  [x] > plus /i64
+  eq. ++> can-add-one-to-minus-one
+    -1.as-i64.plus 1.as-i64
+    0.as-i64
 
-  # Subtraction between `$` and `x`.
-  # Here `x` must be an `i64` object.
-  [x] > minus
-    plus (i64 value).neg > @
-    x > value!
+  eq. ++> can-add-one-to-one
+    1.as-i64.plus 1.as-i64
+    2.as-i64
 
-  # Quotient of the division of `$` by `x` as `org.eolang.i64`.
-  # Here `x` must be an `org.eolang.i64` object.
-  # An `org.eolang.error` is returned if `x` is equal to 0.
-  [x] > div /i64
+  gt. ++> can-be-greater-among-large-negatives
+    -5000000000000000000.as-i64
+    -9000000000000000000.as-i64
 
-  # Tests that i64 number has correct byte representation.
-  [] +> tests-i64-has-valid-bytes
-    eq. > @
-      42.as-i64.as-bytes
-      00-00-00-00-00-00-00-2A
+  -200.as-i64.gt -1000.as-i64 ++> can-be-greater-than-a-smaller-i64
 
-  # Tests that i64 bytes differ from regular number bytes representation.
-  [] +> tests-i64-as-bytes-is-not-equal-to-number-bytes
-    not. > @
-      eq.
-        i64 234.as-bytes
-        234.as-i64.as-bytes
+  -1000.as-i64.gte -1100.as-i64 ++> can-be-greater-than-or-equal-to-a-smaller-i64
 
-  # Tests that converting i64 to i32 and back preserves the value.
-  [] +> tests-i64-to-i32-and-back
-    eq. > @
-      234.as-i64
-      234.as-i64.as-i32.as-i64
+  113.as-i64.gte 113.as-i64 ++> can-be-greater-than-or-equal-to-an-equal-i64
 
-  # Tests that converting negative i64 to i32 and back preserves the value.
-  [] +> tests-negative-i64-to-i32-and-back
-    eq. > @
-      -234.as-i64
-      -234.as-i64.as-i32.as-i64
+  gt. ++> can-be-greater-when-max-is-over-min
+    i64 7F-FF-FF-FF-FF-FF-FF-FF
+    i64 80-00-00-00-00-00-00-00
 
-  # Tests that converting i64 to i32 throws error when out of bounds.
-  3147483647.as-i64.as-i32 > [] +> throws-on-converting-to-i32-if-out-of-bounds
+  -9.223372036854776e18.as-i64.lt 1.as-i64 ++> can-be-less-across-the-full-range
 
-  # Tests that i64 less-than comparison returns true for smaller values.
-  [] +> tests-i64-less-true
-    lt. > @
-      10.as-i64
-      50.as-i64
+  10.as-i64.lt 50.as-i64 ++> can-be-less-than-a-larger-i64
 
-  # Tests that i64 less-than comparison returns false for equal values.
-  [] +> tests-i64-less-equal
-    not. > @
-      lt.
-        10.as-i64
-        10.as-i64
+  -200.as-i64.lte -100.as-i64 ++> can-be-less-than-or-equal-to-a-larger-i64
 
-  # Tests that i64 less-than comparison returns false for larger values.
-  [] +> tests-i64-less-false
-    not. > @
-      lt.
-        10.as-i64
-        -5.as-i64
+  50.as-i64.lte 50.as-i64 ++> can-be-less-than-or-equal-to-an-equal-i64
 
-  # Tests that i64 greater-than comparison returns true for larger values.
-  [] +> tests-i64-greater-true
-    gt. > @
-      -200.as-i64
-      -1000.as-i64
+  not. ++> can-be-less-with-a-large-difference
+    5000000000000000000.as-i64.lt -5000000000000000000.as-i64
 
-  # Tests that i64 greater-than comparison returns false for smaller values.
-  [] +> tests-i64-greater-false
-    not. > @
-      gt.
-        0.as-i64
-        100.as-i64
-
-  # Tests that i64 greater-than comparison returns false for equal values.
-  [] +> tests-i64-greater-equal
-    not. > @
-      gt.
-        0.as-i64
-        0.as-i64
-
-  # Tests that i64 less-than-or-equal comparison returns true for smaller values.
-  [] +> tests-i64-lte-true
-    lte. > @
-      -200.as-i64
-      -100.as-i64
-
-  # Tests that i64 less-than-or-equal comparison returns true for equal values.
-  [] +> tests-i64-lte-equal
-    lte. > @
-      50.as-i64
-      50.as-i64
-
-  # Tests that i64 less-than-or-equal comparison returns false for larger values.
-  [] +> tests-i64-lte-false
-    not. > @
-      lte.
-        0.as-i64
-        -10.as-i64
-
-  # Tests that i64 greater-than-or-equal comparison returns true for larger values.
-  [] +> tests-i64-gte-true
-    gte. > @
-      -1000.as-i64
-      -1100.as-i64
-
-  # Tests that i64 greater-than-or-equal comparison returns true for equal values.
-  [] +> tests-i64-gte-equal
-    gte. > @
-      113.as-i64
-      113.as-i64
-
-  # Tests that i64 greater-than-or-equal comparison returns false for smaller values.
-  [] +> tests-i64-gte-false
-    not. > @
-      gte.
-        0.as-i64
-        10.as-i64
-
-  # Tests that i64 zero equals another i64 zero.
-  [] +> tests-i64-zero-eq-to-i64-zero
-    eq. > @
-      0.@
-      0.@
-
-  # Tests that i64 equality comparison returns true for identical values.
-  [] +> tests-i64-eq-true
-    eq. > @
-      123.@
-      123.@
-
-  # Tests that i64 equality comparison returns false for different values.
-  [] +> tests-i64-eq-false
-    not. > @
-      eq.
-        123.@
-        42.@
-
-  # Tests that i64 addition works correctly.
-  [] +> tests-i64-one-plus-i64-one
-    eq. > @
-      1.as-i64.plus 1.as-i64
-      2.as-i64
-
-  # Tests that i64 subtraction works correctly.
-  [] +> tests-i64-one-minus-i64-one
-    eq. > @
-      1.as-i64.minus 1.as-i64
-      0.as-i64
-
-  # Tests that i64 division by zero throws an error.
-  2.as-i64.div 0.as-i64 > [] +> throws-on-division-i64-by-i64-zero
-
-  # Tests that i64 division by one returns the original value.
-  [] +> tests-i64-div-by-i64-one
-    eq. > @
-      dividend.div 1.as-i64
-      dividend
-    -235.as-i64 > dividend
-
-  # Tests that i64 division with remainder works correctly.
-  [] +> tests-i64-div-with-remainder
-    eq. > @
-      13.as-i64.div -5.as-i64
-      -2.as-i64
-
-  # Tests that i64 division result can be less than one.
-  [] +> tests-i64-div-less-than-i64-one
-    lt. > @
-      1.as-i64.div 5.as-i64
+  eq. ++> can-carry-an-addition-through-all-bytes
+    plus.
+      i64 00-FF-FF-FF-FF-FF-FF-FF
       1.as-i64
+    i64 01-00-00-00-00-00-00-00
 
-  # Tests that i64 multiplication by zero equals zero.
-  [] +> tests-i64-multiply-by-zero
-    eq. > @
-      1000.as-i64.times 0.as-i64
-      0.as-i64
+  eq. ++> can-convert-a-negative-to-i32-and-back
+    -234.as-i64
+    -234.as-i64.as-i32.as-i64
+
+  -3.as-i64.as-number.eq -3 ++> can-convert-a-small-negative-i64-to-a-number
+
+  3.as-i64.as-number.eq 3 ++> can-convert-a-small-positive-i64-to-a-number
+
+  eq. ++> can-convert-an-exact-power-of-two-to-a-number
+    4611686018427387904.as-i64.as-number
+    4611686018427387904
+
+  eq. ++> can-convert-i32-max-without-an-error
+    2147483647.as-i64
+    2147483647.as-i64.as-i32.as-i64
+
+  eq. ++> can-convert-i32-min-without-an-error
+    -2147483648.as-i64
+    -2147483648.as-i64.as-i32.as-i64
+
+  eq. ++> can-convert-i64-min-to-a-number
+    as-number.
+      i64 80-00-00-00-00-00-00-00
+    -9.223372036854776e18
+
+  234.as-i64.eq 234.as-i64.as-i32.as-i64 ++> can-convert-to-i32-and-back
+
+  123.@.eq 123.@ ++> can-equal-the-same-i64
+
+  0.@.eq 0.@ ++> can-equal-zero-to-zero
+
+  42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-keep-the-low-bits-of-a-large-product
+    2147483647.as-i64.times 2147483647.as-i64
+    i64 3F-FF-FF-FF-00-00-00-01
+
+  eq. ++> can-multiply-by-zero
+    1000.as-i64.times 0.as-i64
+    0.as-i64
+
+  eq. ++> can-multiply-mixed-signs
+    -7.as-i64.times 6.as-i64
+    -42.as-i64
+
+  eq. ++> can-multiply-two-negatives
+    -7.as-i64.times -6.as-i64
+    42.as-i64
+
+  eq. ++> can-round-a-tie-to-even-when-converting-to-a-number
+    as-number.
+      i64 00-20-00-00-00-00-00-01
+    9007199254740992
+
+  eq. ++> can-round-i64-max-up-when-converted-to-a-number
+    as-number.
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+    9.223372036854776e18
+
+  eq. ++> can-round-up-above-a-tie-when-converting-to-a-number
+    as-number.
+      i64 00-20-00-00-00-00-00-03
+    9007199254740996
+
+  eq. ++> can-subtract-one-from-one
+    1.as-i64.minus 1.as-i64
+    0.as-i64
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
+    times.
+      i64 40-00-00-00-00-00-00-00
+      4.as-i64
+    0.as-i64
+
+  eq. ++> can-wrap-an-addition-at-max
+    plus.
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+      1.as-i64
+    i64 80-00-00-00-00-00-00-00
+
+  not. ++> cannot-be-greater-than-a-larger-i64
+    0.as-i64.gt 100.as-i64
+
+  not. ++> cannot-be-greater-than-an-equal-i64
+    0.as-i64.gt 0.as-i64
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-i64
+    0.as-i64.gte 10.as-i64
+
+  not. ++> cannot-be-greater-when-min-is-under-max
+    gt.
+      i64 80-00-00-00-00-00-00-00
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+
+  not. ++> cannot-be-less-than-a-smaller-i64
+    10.as-i64.lt -5.as-i64
+
+  not. ++> cannot-be-less-than-an-equal-i64
+    10.as-i64.lt 10.as-i64
+
+  not. ++> cannot-be-less-than-or-equal-to-a-smaller-i64
+    0.as-i64.lte -10.as-i64
+
+  not. ++> cannot-equal-a-different-i64
+    123.@.eq 42.@
+
+  not. ++> cannot-match-the-bytes-of-the-same-number
+    eq.
+      i64 234.as-bytes
+      234.as-i64.as-bytes
+
+  eq. ++> rejects-an-out-of-bounds-conversion-to-i32
+    "recovered"
+    3147483647.as-i64.as-i32
+      "recovered" > [message]
+
+  2147483648.as-i64.as-i32 --> stops-on-converting-i32-max-plus-one-to-i32
+
+  -2147483649.as-i64.as-i32 --> stops-on-converting-i32-min-minus-one-to-i32
+
+  3147483647.as-i64.as-i32 --> stops-on-converting-out-of-bounds-to-i32

--- a/objects/i64/div.eo
+++ b/objects/i64/div.eo
@@ -1,0 +1,124 @@
+# Integer division of the `i64` number `n` by the `i64` number `x`, truncated
+# toward zero. The quotient is built by restoring long division over the
+# magnitudes of both operands, with the sign applied afterwards. When `x` is
+# zero, the caller-supplied `cant-divide` fallback is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package i64
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x cant-divide] > div
+  if. > @
+    x.as-bytes.eq 00-00-00-00-00-00-00-00
+    cant-divide
+      "i64 cannot be divided by zero"
+    if.
+      eq.
+        and.
+          n.as-bytes.xor x.as-bytes
+          80-00-00-00-00-00-00-00
+        80-00-00-00-00-00-00-00
+      as-bytes.
+        plus.
+          i64
+            not.
+              looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
+          i64 00-00-00-00-00-00-00-01
+      i64 quotient
+  00-00-00-00-00-00-00-01.left i > [i] >> bit
+  [index remainder quot] >> looped
+    if. > @
+      index.lt 0
+      quot
+      if.
+        eq.
+          or. >> carry-out!
+            and. >> both-negative!
+              shifted.and 80-00-00-00-00-00-00-00 >> shifted-sign!
+              subtrahend.and 80-00-00-00-00-00-00-00 >> divisor-sign!
+            and. >> mixed-signs-with-nonneg-trial!
+              shifted-sign.xor divisor-sign >> signs-differ!
+              next-rem.xor 80-00-00-00-00-00-00-00 >> trial-nonnegative!
+          80-00-00-00-00-00-00-00
+        looped
+          index.minus 1
+          as-bytes. >> next-rem!
+            plus.
+              i64 shifted
+              i64 subtrahend
+          quot.or >>!
+            bit index
+        looped
+          index.minus 1
+          or. >> shifted!
+            remainder.left 1
+            and.
+              right.
+                magnitude n.as-bytes
+                index
+              00-00-00-00-00-00-00-01
+          quot
+  as-bytes. >> subtrahend
+    plus.
+      i64
+        not.
+          if. > [b] >> magnitude
+            eq.
+              b.and 80-00-00-00-00-00-00-00
+              80-00-00-00-00-00-00-00
+            as-bytes.
+              plus.
+                i64 b.not
+                i64 00-00-00-00-00-00-00-01
+            b
+          | x.as-bytes
+      i64 00-00-00-00-00-00-00-01
+
+  eq. ++> can-divide-a-large-dividend
+    4611686018427387904.as-i64.div 2.as-i64
+    2305843009213693952.as-i64
+
+  ++> can-divide-by-one
+    eq. > @
+      dividend.div 1.as-i64
+      dividend
+    -235.as-i64 > dividend
+
+  lt. ++> can-divide-into-less-than-one
+    1.as-i64.div 5.as-i64
+    1.as-i64
+
+  eq. ++> can-divide-min-by-one
+    div.
+      i64 80-00-00-00-00-00-00-00
+      1.as-i64
+    i64 80-00-00-00-00-00-00-00
+
+  eq. ++> can-divide-two-negatives
+    -13.as-i64.div -5.as-i64
+    2.as-i64
+
+  eq. ++> can-divide-with-a-remainder
+    13.as-i64.div -5.as-i64
+    -2.as-i64
+
+  eq. ++> can-truncate-toward-zero
+    -13.as-i64.div 5.as-i64
+    -2.as-i64
+
+  eq. ++> can-wrap-min-divided-by-minus-one
+    div.
+      i64 80-00-00-00-00-00-00-00
+      -1.as-i64
+    i64 80-00-00-00-00-00-00-00
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    2.as-i64.div
+      0.as-i64
+      "recovered" > [message]
+
+  2.as-i64.div 0.as-i64 --> stops-on-division-by-zero

--- a/objects/i8.eo
+++ b/objects/i8.eo
@@ -1,0 +1,140 @@
+# Signed 8-bit integer.
+# Here `as-bytes` must be a `bytes` object of exactly one byte,
+# interpreted as two's complement.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[as-bytes] > i8
+  as-bytes > @
+  [] > as-i16
+    i16 > @
+      concat.
+        if. >>
+          eq.
+            as-bytes.and 80-
+            00-
+          00-
+          FF-
+        as-bytes
+  as-i16.as-number > as-number
+  [x cant-divide] > div
+    if. > @
+      eq.
+        x.as-i8 >> other
+        00-
+      cant-divide
+        "Can't divide %d by i8 zero".printf
+          * as-number
+      i8
+        slice.
+          as-bytes.
+            as-i16.div other.as-i16
+          1
+          1
+  as-i16.gt x.as-i8.as-i16 > [x] > gt
+  as-i16.gte x.as-i8.as-i16 > [x] > gte
+  as-i16.lt x.as-i8.as-i16 > [x] > lt
+  as-i16.lte x.as-i8.as-i16 > [x] > lte
+  i8 > [x] > minus
+    slice.
+      as-bytes.
+        as-i16.minus x.as-i8.as-i16
+      1
+      1
+  times FF-.as-i8 > neg
+  i8 > [x] > plus
+    slice.
+      as-bytes.
+        as-i16.plus x.as-i8.as-i16
+      1
+      1
+  i8 > [x] > times
+    slice.
+      as-bytes.
+        as-i16.times x.as-i8.as-i16
+      1
+      1
+
+  eq. ++> can-add-one-to-one
+    01-.as-i8.plus 01-.as-i8
+    02-.as-i8
+
+  eq. ++> can-add-with-overflow
+    7F-.as-i8.plus 01-.as-i8
+    80-.as-i8
+
+  32-.as-i8.gte 32-.as-i8 ++> can-be-greater-than-or-equal-to-an-equal-i8
+
+  32-.as-i8.gt C8-.as-i8 ++> can-be-greater-when-positive-than-negative
+
+  0A-.as-i8.lt 32-.as-i8 ++> can-be-less-than-a-larger-i8
+
+  32-.as-i8.lte 32-.as-i8 ++> can-be-less-than-or-equal-to-an-equal-i8
+
+  C8-.as-i8.lt 0A-.as-i8 ++> can-be-less-when-negative-than-positive
+
+  eq. ++> can-divide-by-one
+    C8-.as-i8.div 01-.as-i8
+    C8-.as-i8
+
+  eq. ++> can-divide-with-a-remainder
+    0D-.as-i8.div FB-.as-i8
+    FE-.as-i8
+
+  2A-.as-i8.eq 2A-.as-i8 ++> can-equal-the-same-i8
+
+  2A-.as-i8.as-bytes.eq 2A- ++> can-expose-valid-bytes
+
+  eq. ++> can-expose-valid-bytes-of-a-negative
+    -56.as-i64.as-i32.as-i16.as-bytes.slice
+      1
+      1
+    C8-
+
+  eq. ++> can-multiply-two-negatives
+    FF-.as-i8.times FF-.as-i8
+    01-.as-i8
+
+  eq. ++> can-multiply-two-positives
+    06-.as-i8.times 07-.as-i8
+    2A-.as-i8
+
+  2A-.as-i8.neg.eq D6-.as-i8 ++> can-negate-itself
+
+  C8-.as-i8.as-number.eq -56 ++> can-read-a-high-bit-as-negative
+
+  eq. ++> can-subtract-one-from-one
+    01-.as-i8.minus 01-.as-i8
+    00-.as-i8
+
+  eq. ++> can-subtract-with-overflow
+    80-.as-i8.minus 01-.as-i8
+    7F-.as-i8
+
+  eq. ++> can-widen-a-negative-to-i16-with-sign-extension
+    C8-.as-i8.as-i16.as-bytes
+    FF-C8
+
+  eq. ++> can-widen-a-positive-to-i16-with-a-zero-prefix
+    2A-.as-i8.as-i16.as-bytes
+    00-2A
+
+  not. ++> cannot-be-less-than-an-equal-i8
+    0A-.as-i8.lt 0A-.as-i8
+
+  not. ++> cannot-equal-a-different-i8
+    2A-.as-i8.eq 2B-.as-i8
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    02-.as-i8.div
+      00-.as-i8
+      "recovered" > [message]
+
+  02-.as-i8.div 00-.as-i8 --> stops-on-division-by-zero

--- a/objects/input.eo
+++ b/objects/input.eo
@@ -1,0 +1,16 @@
+# Input is an abstract source of bytes that can be read sequentially.
+# Any input decorates the object bound to its `@` attribute, which must
+# provide a `read` object that takes the amount of bytes to read and
+# returns an input block - a dataizable portion of bytes that also has
+# its own `read` to fetch the next portion. See `input.dead`,
+# `input.as-bytes`, `input.length`, `input.tee`, and `bytes.as-input`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint unit-test-missing
+
+[@] > input

--- a/objects/input/as-bytes.eo
+++ b/objects/input/as-bytes.eo
@@ -1,0 +1,34 @@
+# Reads all bytes from the provided `input` and returns them as bytes.
+#
+# Example usage:
+# ```
+# as-bytes > b
+#   bytes.as-input 01-02-03-04-05
+# ```
+# After dataization, `b` equals `01-02-03-04-05`.
+
++alias bytes.as-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package input
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[input] > as-bytes
+  malloc.of > @
+    0
+    seq * > [m] >>
+      Q.input.copied input m.to-output
+      m
+
+  ++> can-convert-bytes-to-an-input-and-back
+    eq. > @
+      Q.input.as-bytes
+        bytes.as-input b
+      b
+    01-02-03-04-05-06-07-08 > b
+
+  eq. ++> can-return-empty-bytes-from-a-dead-input
+    Q.input.as-bytes dead
+    --

--- a/objects/input/copied.eo
+++ b/objects/input/copied.eo
@@ -1,0 +1,75 @@
+# Copies all bytes from the provided `input` to the provided `output`
+# and returns the total number of bytes copied.
+#
+# Example usage:
+# ```
+# copied > total-bytes
+#   bytes.as-input 01-02-03-04-05
+#   memory.to-output
+# ```
+# After dataization, `total-bytes` equals 5, and all bytes have been
+# copied from input to output.
+
++alias bytes.as-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package input
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[input output] > copied
+  Q.input.length > @
+    Q.input.tee
+      input
+      output
+
+  eq. ++> can-copy-all-bytes-and-return-the-length
+    malloc.of
+      5
+      seq * > [m]
+        Q.input.copied
+          bytes.as-input 01-02-03-04-05
+          m.to-output
+        m
+    01-02-03-04-05
+
+  eq. ++> can-handle-a-dead-input
+    Q.input.copied
+      Q.input.dead
+      Q.output.dead
+    0
+
+  eq. ++> can-handle-an-empty-input
+    malloc.of
+      0
+      seq * > [m]
+        Q.input.copied
+          bytes.as-input --
+          m.to-output
+        m
+    --
+
+  eq. ++> can-handle-large-data
+    20
+    malloc.of
+      20
+      Q.input.copied > [m]
+        bytes.as-input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14
+        m.to-output
+
+  eq. ++> can-return-the-byte-count
+    malloc.of
+      10
+      Q.input.copied > [m]
+        bytes.as-input 01-02-03-04-05-06-07-08-09-10
+        m.to-output
+    10
+
+  eq. ++> can-return-zero-for-an-empty-input
+    malloc.of
+      0
+      Q.input.copied > [m]
+        bytes.as-input --
+        m.to-output
+    0

--- a/objects/input/dead.eo
+++ b/objects/input/dead.eo
@@ -1,0 +1,35 @@
+# Dead input is an input that reads from nowhere and always
+# returns empty sequence of bytes (`--`). Here `origin` is the input
+# this one is taken off, as in `i.dead`. It is ignored, because a dead
+# input reads from nowhere anyway.
+
++alias bytes.as-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package input
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[origin] > dead
+  [size] > read
+    [] >> input-block
+      -- > @
+      input-block > [size] > read
+    | > @
+
+  eq. ++> can-be-taken-off-any-input
+    read.
+      dead.
+        input
+          bytes.as-input 01-02-03
+      10
+    --
+
+  ++> can-read-empty-bytes
+    and. > @
+      i1.eq --
+      eq.
+        i1.read 10
+        --
+    dead.read 10 > i1

--- a/objects/input/length.eo
+++ b/objects/input/length.eo
@@ -1,0 +1,40 @@
+# Reads all the bytes from provided `input` and returns its length.
+
++alias bytes.as-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package input
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[input] > length
+  [input length] >> rec-read
+    if. > @
+      chunk.size.eq 0
+      length
+      rec-read
+        chunk
+        length.plus chunk.size
+    ^. > chunk
+      read.
+        input.read 4096
+  | > @
+    input
+    0
+
+  eq. ++> can-read-all-bytes-and-return-the-length
+    Q.input.length
+      bytes.as-input 01-02-03-04-05-06-07-08-09-10
+    10
+
+  eq. ++> can-copy-all-bytes-to-an-output-and-return-the-length
+    malloc.of
+      10
+      seq * > [m]
+        Q.input.length
+          Q.input.tee
+            bytes.as-input 01-02-03-04-05-06-07-08-09-10
+            m.to-output
+        m
+    01-02-03-04-05-06-07-08-09-10

--- a/objects/input/tee.eo
+++ b/objects/input/tee.eo
@@ -1,0 +1,83 @@
+# Tee input is an input that reads from provided `input`,
+# writes to provided `output` and behaves as provided `input`.
+# To copy bytes input to memory you can do:
+# ```
+# malloc.of > copied
+#   5
+#   [m]
+#     read. > @
+#       tee
+#         bytes.as-input 01-02-03-04-05
+#         m.to-output
+#       5
+# ```
+# After dataization `copied` is equal to `01-02-03-04-05` which are read
+# from memory.
+
++alias bytes.as-input
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package input
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[input output] > tee
+  [size] > read
+    read. > @
+      input-block
+        input
+        output
+        --
+      size
+    [input output buffer] > input-block
+      buffer > @
+      [size] > read
+        seq * > @
+          written
+          input-block chunk written chunk.as-bytes
+        ^. (input.read size).read > chunk
+        ^. (output.write chunk).write > written
+
+  eq. ++> can-read-from-bytes-and-write-to-memory
+    malloc.of
+      5
+      read. > [mem]
+        Q.input.tee
+          bytes.as-input 01-02-03-04-05
+          mem.to-output
+        5
+    01-02-03-04-05
+
+  eq. ++> can-read-from-bytes-and-write-to-memory-by-portions
+    malloc.of
+      5
+      seq * > [m]
+        read.
+          read.
+            read.
+              Q.input.tee
+                bytes.as-input 01-02-03-04-05
+                m.to-output
+              2
+            2
+          1
+        m
+    01-02-03-04-05
+
+  ++> can-read-from-bytes-and-write-to-two-memory-blocks
+    eq. > @
+      malloc.of
+        6
+        [m1]
+          malloc.of > @
+            5
+            seq * > [m2] >>
+              read.
+                Q.input.tee
+                  Q.input.tee (bytes.as-input 01-02-03-04-05) m2.to-output
+                  m1.to-output
+                5
+              m1.write 5 2A-
+              m1
+      01-02-03-04-05-2A

--- a/objects/malloc.eo
+++ b/objects/malloc.eo
@@ -1,13 +1,4 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
-+rt node eo2js-runtime:0.0.0
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-
-# The `malloc` object is an abstraction of a storage of data in heap
+# Object `malloc` is an abstraction of a storage of data in heap
 # memory. The implementation of `malloc` is platform dependent. It may
 # use either OS-level or VM-level memory management mechanism.
 #
@@ -60,397 +51,332 @@
 # ```
 # Here the void attribute in the scope object is memory-block object which provides API to write
 # and read data to the memory.
-[] > malloc
-  # Allocates empty block in memory.
-  [scope] > empty
-    malloc.of > @
-      0
-      scope
 
-  # Allocates block in memory for given `object`. After allocation the provided object is dataized
-  # and the data is written into memory.
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > malloc
+  malloc.of > [scope] > empty
+    0
+    scope
   [object scope] > for
     malloc.of > @
-      bts.size
-      [m] >>
-        seq * > @
-          m.write 0 bts
-          scope m
-    (dataized object).as-bytes > bts
+      size.
+        object >> bts!
+      seq * > [m] >>
+        m.write 0 bts
+        scope m
+  [] > of /Q.bytes
+    ? > size /Q.number
+    ? > scope /{Q.chunk}
 
-  # Allocates block in memory of given `size`. After allocation, `size` zero bytes are
-  # written into memory.
-  [size scope] > of
-    # Dataizes given `scope` and returns the result of the dataization as `org.eolang.bytes`.
-    [] > @ /bytes
-
-    # Allocated block in memory that provides an API for writing and reading.
-    [id] > allocated
-      get > @
-      # Just get all the data from the allocated block in memory.
-      read 0 size > get
-
-      # Returns size of allocated block in memory as `org.eolang.number`.
-      [] > size /number
-
-      # Resizes allocated block in memory and returns `true`.
-      # Here `size` must be positive `number`.
-      # The `error` returned if failed to resize block in memory.
-      # Returns `org.eolang.malloc.of.allocated` object.
-      [size] > resized /Q.malloc.of.allocated
-
-      # Reads the data from block in memory with offset `source` and `length` and writes
-      # to the block with offset `target`.
-      # Returns `true` on success, or `error` on failure.
-      [source target length] > copy
-        write > @
-          target
-          read source length
-
-      # Read `length` bytes with `offset` from the allocated block in memory and return them
-      # as `org.eolang.bytes`.
-      [offset length] > read /bytes
-
-      # Write `data` with `offset` to the allocated block in memory
-      # and return `org.eolang.true`.
-      [offset data] > write /bool
-
-      # Put `object` into the allocated block in memory. The `object` is supposed to be dataizable.
-      [object] > put
-        seq * > @
-          write 0 object
-          get
-
-  # Tests that malloc.of can write data into allocated memory block and retrieve it.
-  [] +> tests-writes-into-memory-of
-    mem.eq 10 > @
-    malloc.of > mem
-      8
-      [m]
-        seq > @
-          *
-            m.write 0 10
-            m
-
-  # Tests that malloc.for can allocate memory for an object and put new data into it.
-  [] +> tests-puts-into-memory-for
-    mem.eq 10 > @
-    malloc.for > mem
-      0
-      m.put 10 > [m]
-
-  # Tests that malloc returns the correct size of allocated memory block from scope.
-  [] +> tests-returns-size-from-scope
-    eq. > @
-      malloc.of
-        5
-        m.size > [m]
-      5
-
-  # Tests that malloc scope can be dataized multiple times correctly.
-  [] +> tests-malloc-scope-is-dataized-twice
-    eq. > @
-      2
-      malloc.for
-        0
-        [f]
-          seq > @
-            *
-              second
-              second
-          malloc.of > second
-            1
-            f.put (f.as-number.plus 1) > [s] >>
-
-  # Tests that malloc.for correctly writes the initial value provided during allocation.
-  [] +> tests-malloc-for-writes-first-init-value
-    eq. > @
-      malloc.for
-        42
-        m > [m]
-      42
-
-  # Tests that malloc.put overwrites previous data starting from offset 0.
-  [] +> tests-malloc-puts-over-the-previous-data
-    eq. > @
-      42.as-bytes.concat
-        "orld!".as-bytes
-      mem
-    malloc.of > mem
-      13
-      [m]
-        seq > @
-          *
-            m.put "Hello, world!"
-            m.put 42
-
-  # Tests that malloc can rewrite data and increment its own value in memory.
-  [] +> tests-malloc-rewrites-and-increments-itself
-    mem.eq 6 > @
-    malloc.of > mem
-      8
-      [m]
-        seq > @
-          *
-            m.write 0 1
-            m.put (m.as-number.plus 5)
-
-  # Tests that two separate malloc objects can store different values independently.
-  [] +> tests-writes-into-two-malloc-objects
-    and. > @
-      (malloc.of 8 (m.put 10 > [m])).eq 10
-      (malloc.of 8 (m.put 20 > [m])).eq 20
-
-  # Tests that malloc throws an error when trying to put data larger than allocated space for boolean.
-  [] +> throws-on-overflow-boolean-malloc
-    malloc.for > @
-      false
-      m.put 86124867.88 > [m]
-
-  # Tests that malloc throws an error when trying to put a string larger than allocated space.
-  [] +> throws-on-overflow-string-malloc
-    malloc.for > @
-      "Hello"
-      m.put "Much longer string!" > [m]
-
-  # Tests that malloc correctly handles integer values within the allocated memory size.
-  [] +> tests-malloc-is-strictly-sized-int
-    eq. > @
-      malloc.for
-        12248
-        m.put 2556 > [m]
-      2556
-
-  # Tests that malloc correctly handles float values and maintains type consistency.
-  [] +> tests-malloc-is-strictly-typed-float
-    eq. > @
-      malloc.for
-        245.88
-        m.put 82.22 > [m]
-      82.22
-
-  # Tests that malloc handles string data within the allocated memory size constraints.
-  [] +> tests-memory-is-strictly-sized-string
-    eq. > @
-      malloc.for
-        "Hello"
-        m.put "Prot" > [m]
-      "Proto"
-
-  # Tests that malloc correctly handles boolean values and type consistency.
-  [] +> tests-malloc-is-strictly-typed-bool
-    malloc.for > @
-      false
-      m.put true > [m]
-
-  # Tests that malloc assigns a positive unique identifier to each allocated memory block.
-  [] +> tests-malloc-gives-id-to-allocated-block
-    malloc.of > @
-      1
-      m.put (m.id.gt 0) > [m]
-
-  # Tests that malloc allocates memory blocks with the exact size specified.
-  [] +> tests-malloc-allocates-right-size-block
+  ++> can-allocate-a-block-of-the-right-size
     malloc.of > @
       1
       [b]
         malloc.of > @
           10
-          b.put (m.size.eq 10) > [m] >>
+          b.put > [m] >>
+            m.size.eq 10
 
-  # Tests that malloc can write data to specific offsets and read it back correctly.
-  [] +> tests-malloc-writes-and-reads
-    malloc.of > @
+  malloc.empty ++> can-allocate-an-empty-block
+    m.size.eq 0 > [m]
+
+  eq. ++> can-allocate-zero-bytes
+    0
+    malloc.of
+      0
+      m.size > [m]
+
+  ++> can-calculate-only-once
+    eq. > @
+      malloc.for 0 x
       1
-      [b]
-        malloc.of > @
-          12
-          [m] >>
-            seq > @
-              *
-                m.write 0 "Hello, "
-                m.write 7 "Jeff!"
-                b.put
-                  eq.
-                    m.read 0 12
-                    "Hello, Jeff!"
+    [m] > x
+      seq * > @
+        a.neg.neg.neg.neg.eq 42
+        m
+      seq * > [] > a
+        m.put
+          m.as-number.plus 1
+        42
 
-  # Tests that malloc correctly concatenates strings when writing with offset overwriting.
-  [] +> tests-malloc-concacts-strings-with-offset
+  ++> can-concat-strings-with-an-offset
     malloc.of > @
       1
       [b]
         malloc.of > @
           3
-          [m] >>
-            seq > @
-              *
-                m.write 0 "XXX"
-                m.write 1 "Y"
-                b.put
-                  (m.read 0 3).eq "XYX"
+          seq * > [m] >>
+            m.write 0 "XXX"
+            m.write 1 "Y"
+            b.put
+              eq.
+                m.read 0 3
+                "XYX"
 
-  # Tests that malloc resizes the block when writing beyond allocated memory bounds with offset.
-  [] +> writes-beyond-offset-and-resizes
-    malloc.of > @
-      1
-      [m]
-        seq * > @
-          m.write 1 true
-          m.size.eq 2
+  malloc.for ++> can-copy-and-resize-to-a-target
+    0
+    seq * > [m]
+      m.copy
+        3
+        9
+        1
+      m.size.eq 10
 
-  # Tests that malloc can read data from specific offset with specified length correctly.
-  [] +> tests-malloc-reads-with-offset-and-length
-    malloc.of > @
-      1
-      [b]
-        malloc.of > @
-          10
-          [m] >>
-            seq > @
-              *
-                m.write 2 "Hello"
-                b.put
-                  (m.read 2 5).eq "Hello"
-
-  # Creates memory block of zero bytes (this should be a legal operation).
-  [] +> tests-allocates-zero-bytes
-    eq. > @
-      0
-      malloc.of
+  malloc.for ++> can-copy-data-from-start-to-end
+    01-02-03-04-05-06
+    and. > [m]
+      m.copy
         0
-        m.size > [m]
+        3
+        3
+      m.get.eq 01-02-03-01-02-03
 
-  # Tests that malloc can increase the allocated block size and preserve existing data.
-  [] +> tests-malloc-increases-block-size
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          01-02-03-04
-          [m] >>
-            ^.b.put > @
-              and.
-                (m.resized 6).size.eq 6
-                m.get.eq 01-02-03-04-00-00
+  malloc.for ++> can-copy-data-inside-itself
+    01-02-03-04-05
+    and. > [m]
+      m.copy
+        1
+        2
+        2
+      m.get.eq 01-02-02-03-05
 
-  # Tests that malloc can decrease the allocated block size and truncate data accordingly.
-  [] +> tests-malloc-decreases-block-size
+  ++> can-dataize-a-scope-twice
+    2.eq > @
+      malloc.for
+        0
+        [f]
+          seq > @
+            * second second
+          malloc.of > second
+            1
+            f.put > [s] >>
+              f.as-number.plus 1
+
+  ++> can-decrease-the-block-size
     malloc.of > @
       1
       [b]
         malloc.for > @
           01-02-03-04-05
-          [m] >>
-            ^.b.put > @
-              and.
-                (m.resized 3).size.eq 3
-                m.get.eq 01-02-03
+          b.put > [m] >>
+            and.
+              eq. (m.resized 3).size 3
+              m.get.eq 01-02-03
 
-  # Tests that malloc throws an error when attempting to resize to negative size.
-  [] +> throws-on-changing-size-to-negative
-    malloc.of > @
-      1
-      m.resized -1 > [m]
-
-  # Tests that malloc.empty creates a memory block with zero size.
-  [] +> tests-malloc-empty-is-empty
-    malloc.empty > @
-      m.size.eq 0 > [m]
-
-  # Tests that malloc can copy data from one memory location to another within the same block.
-  [] +> tests-copies-data-inside-itself
-    malloc.for > @
-      01-02-03-04-05
-      [m]
-        and. > @
-          m.copy 1 2 2
-          m.get.eq 01-02-02-03-05
-
-  # Tests that malloc can copy data from the beginning to the end of the memory block.
-  [] +> tests-copies-data-from-start-to-end
-    malloc.for > @
-      01-02-03-04-05-06
-      [m]
-        and. > @
-          m.copy 0 3 3
-          m.get.eq 01-02-03-01-02-03
-
-  # Tests that malloc throws an error when copying from an invalid source offset.
-  [] +> throws-on-copying-with-wrong-source
-    malloc.for > @
-      0
-      m.copy 9 1 1 > [m]
-
-  # Tests that malloc resizes the block when copying to a target offset beyond allocated memory.
-  [] +> copies-and-resizes-to-target
-    malloc.for > @
-      0
-      [m]
-        seq * > @
-          m.copy 3 9 1
-          m.size.eq 10
-
-  # Tests that malloc throws an error when copying with an invalid length parameter.
-  [] +> throws-on-copying-with-wrong-length
-    malloc.for > @
-      0
-      m.copy 3 1 9 > [m]
-
-  # Tests that the runtime calculates expressions only once.
-  [] +> tests-calculates-only-once
-    eq. > @
-      malloc.for
-        0
-        # Checks that a is only evaluated once despite multiple negations.
-        [m] > x
-          seq > @
-            *
-              a.neg.neg.neg.neg.eq 42
-              m
-          # Increments the counter and returns 42.
-          [] > a
-            seq > @
-              *
-                ^.m.put (^.m.as-number.plus 1)
-                42
-      1
-
-  # Tests that the runtime handles recursion without arguments.
-  [] +> tests-recursion-without-arguments
-    eq. > @
-      malloc.for
-        4
-        [m] >>
-          func m > @
-      0
-    # Decrements n until it reaches zero, then returns it.
-    [n] > func
-      if. > @
-        n.as-number.gt 0
-        seq
-          *
-            n.put (n.as-number.minus 1)
-            ^.func n
-        n
-
-  # Tests that the runtime constants defend against side effects.
-  [] +> tests-constant-defends-against-side-effects
+  ++> can-defend-a-constant-against-side-effects
     eq. > @
       malloc.for
         7
         [m] >>
           m.put > @
-            times.
-              num
-              num
-          number > num
-            ^.inc m > n!
+            num.times num
+          number (inc m)! > num
       64
-    # Increments x and returns its new value.
-    [x] > inc
-      seq > @
-        *
-          x.put
-            x.as-number.plus 1
-          x.as-number
+    seq * > [x] > inc
+      x.put
+        x.as-number.plus 1
+      x.as-number
+
+  malloc.of ++> can-give-an-id-to-an-allocated-block
+    1
+    m.put > [m]
+      m.id.gt 0
+
+  eq. ++> can-grow-an-empty-block-on-the-first-put
+    malloc.empty
+      m.put 42 > [m]
+    42
+
+  ++> can-increase-the-block-size
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          01-02-03-04
+          b.put > [m] >>
+            and.
+              eq. (m.resized 6).size 6
+              m.get.eq 01-02-03-04-00-00
+
+  malloc.for ++> can-keep-the-size-of-a-bool-block
+    false
+    m.put true > [m]
+
+  eq. ++> can-keep-the-size-of-a-float-block
+    malloc.for
+      245.88
+      m.put 82.22 > [m]
+    82.22
+
+  eq. ++> can-keep-the-size-of-a-string-block
+    malloc.for
+      "Hello"
+      m.put "Prot" > [m]
+    "Proto"
+
+  eq. ++> can-keep-the-size-of-an-integer-block
+    malloc.for
+      12248
+      m.put 2556 > [m]
+    2556
+
+  ++> can-put-into-a-block-made-by-for
+    mem.eq 10 > @
+    malloc.for > mem
+      0
+      m.put 10 > [m]
+
+  ++> can-put-over-the-previous-data
+    eq. > @
+      42.as-bytes.concat "orld!".as-bytes
+      mem
+    malloc.of > mem
+      13
+      seq * > [m]
+        m.put
+          "Hello, world!"
+        m.put 42
+
+  ++> can-read-with-an-offset-and-a-length
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          10
+          seq * > [m] >>
+            m.write 2 "Hello"
+            b.put
+              eq.
+                m.read 2 5
+                "Hello"
+
+  ++> can-recurse-without-arguments
+    eq. > @
+      malloc.for
+        4
+        func m > [m] >>
+      0
+    if. > [n] >> func
+      n.as-number.gt 0
+      seq *
+        n.put
+          n.as-number.minus 1
+        func n
+      n
+
+  eq. ++> can-return-the-size-from-a-scope
+    malloc.of
+      5
+      m.size > [m]
+    5
+
+  ++> can-rewrite-and-increment-itself
+    mem.eq 6 > @
+    malloc.of > mem
+      8
+      seq * > [m]
+        m.write 0 1
+        m.put
+          m.as-number.plus 5
+
+  ++> can-write-and-read
+    malloc.of > @
+      1
+      [b]
+        malloc.of > @
+          12
+          seq * > [m] >>
+            m.write
+              0
+              "Hello, "
+            m.write 7 "Jeff!"
+            b.put
+              eq.
+                m.read 0 12
+                "Hello, Jeff!"
+
+  malloc.of ++> can-write-beyond-an-offset-and-resize
+    1
+    seq * > [m]
+      m.write 1 true
+      m.size.eq 2
+
+  ++> can-write-into-a-block-made-by-of
+    mem.eq 10 > @
+    malloc.of > mem
+      8
+      seq * > [m]
+        m.write 0 10
+        m
+
+  and. ++> can-write-into-two-allocated-blocks
+    eq.
+      malloc.of
+        8
+        m.put 10 > [m]
+      10
+    eq.
+      malloc.of
+        8
+        m.put 20 > [m]
+      20
+
+  eq. ++> can-write-the-initial-value
+    malloc.for
+      42
+      m > [m]
+    42
+
+  eq. ++> rejects-reading-over-the-limit
+    01-02
+    malloc.of
+      1
+      m.read > [m]
+        0
+        10
+        01-02 > [ex]
+
+  malloc.of --> stops-on-changing-the-size-to-a-fraction
+    1
+    m.resized 1.5 > [m]
+
+  malloc.of --> stops-on-changing-the-size-to-a-negative
+    1
+    m.resized -1 > [m]
+
+  malloc.for --> stops-on-copying-with-a-wrong-length
+    0
+    m.copy > [m]
+      3
+      1
+      9
+
+  malloc.for --> stops-on-copying-with-a-wrong-source
+    0
+    m.copy > [m]
+      9
+      1
+      1
+
+  malloc.for --> stops-on-overflowing-a-bool-block
+    false
+    m.put 8.612486788E7 > [m]
+
+  malloc.for --> stops-on-overflowing-a-string-block
+    "Hello"
+    m.put > [m]
+      "Much longer string!"
+
+  malloc.for --> stops-on-reading-over-the-limit
+    10
+    m.read > [m]
+      0
+      100

--- a/objects/map.eo
+++ b/objects/map.eo
@@ -1,0 +1,311 @@
+# Hash-map.
+# Here `pairs` must be a `tuple` of `map.entry` object.
+# The `map.entry.key` must be a dataizable object, `map.entry.value` may be any object.
+# Two keys are the same only when their hash codes and their raw bytes are equal.
+# A hash code alone is not enough, since `bytes.hash` is a `31 * acc + byte`
+# polynomial and therefore has collisions, e.g. `"Aa"` and `"BB"` both hash to 2112.
+# Comparing hash codes only would make such distinct keys overwrite each other.
+# Every key is dataized to bytes exactly once, when the map is built, and the
+# hash code is derived from those bytes rather than from the key itself,
+# so that keys with side effects are never evaluated more than once.
+
++alias tuple.filtered
++alias bytes.hash
++alias tuple.mapped
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint decorated-formation
++unlint mandatory-package
+
+[pairs] > map
+  [] > @
+    ctor > @
+      if.
+        pairs.length.eq 0
+        *
+        @.
+          [tup] >> rec-rebuild
+            if. > @
+              tup.length.eq 0
+              *
+              others.with
+                [] >>
+                  ^.hash > hash
+                  ^.kbts > kbts
+                  tup.head.key > key
+                  tup.head.value > value
+            bytes.hash >> hash!
+              tup.head.key.as-bytes >> kbts!
+            tuple.filtered > others
+              prev
+              not. > [ent] >>
+                and.
+                  ent.hash.eq hash
+                  ent.kbts.eq kbts
+            @. > prev
+              rec-rebuild tup.tail
+          | pairs
+  [entries] > ctor
+    [key] > found
+      if. > @
+        size.eq 0
+        not-found
+        [tup] >> rec-key-search
+          if. > @
+            tup.length.eq 0
+            not-found
+            prev.exists.if
+              prev
+              if.
+                and.
+                  tup.head.hash.eq hash
+                  tup.head.kbts.eq kbts
+                [] >>
+                  true > exists
+                  tup.head.value > [cant-get] > get
+                not-found
+          @. > prev
+            rec-key-search tup.tail
+        | entries
+      bytes.hash >> hash!
+        key.as-bytes >> kbts!
+      [] > not-found
+        false > exists
+        cant-get > [cant-get] > get
+          "Object by hash code %d from given key does not exists".printf
+            * hash
+    exists. > [key] > has
+      found key
+    tuple.mapped > keys
+      entries
+      entry.key > [entry]
+    entries.length > size
+    tuple.mapped > values
+      entries
+      entry.value > [entry]
+    [key value] > with
+      map.ctor > @
+        with.
+          tuple.filtered
+            entries
+            not. > [entry] >>
+              and.
+                hash.eq entry.hash
+                kbts.eq entry.kbts
+          [] >>
+            ^.hash > hash
+            ^.kbts > kbts
+            ^.key > key
+            ^.value > value
+      bytes.hash >> hash!
+        key.as-bytes >> kbts!
+    [key] > without
+      map.ctor > @
+        tuple.filtered
+          entries
+          not. > [entry] >>
+            and.
+              hash.eq entry.hash
+              kbts.eq entry.kbts
+      bytes.hash >> hash!
+        key.as-bytes >> kbts!
+  [key value] > entry
+
+  ++> can-add-a-key-colliding-with-an-existing-one
+    and. > @
+      2.eq mp.size
+      2.eq
+        get.
+          mp.found "BB"
+    with. > mp
+      map *
+        map.entry "Aa" 1
+      "BB"
+      2
+
+  ++> can-add-a-new-pair
+    and. > @
+      2.eq mp.size
+      mp.has "two"
+    with. > mp
+      map *
+        map.entry "one" 1
+      "two"
+      2
+
+  ++> can-find-an-element-by-a-key
+    2.eq found.get > @
+    mp.found "two" > found
+    map * > mp
+      map.entry "one" 1
+      map.entry "two" 2
+      map.entry "three" 3
+
+  ++> can-find-the-value-of-each-key-with-colliding-hashes
+    and. > @
+      1.eq first.get
+      2.eq second.get
+    mp.found "Aa" > first
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+    mp.found "BB" > second
+
+  has. ++> can-have-an-element-with-a-key
+    map *
+      map.entry "one" 1
+      map.entry "two" 2
+    "two"
+
+  ++> can-keep-both-keys-with-colliding-hashes
+    2.eq mp.size > @
+    map * > mp
+      map.entry "Aa" 1
+      map.entry "BB" 2
+
+  ++> can-keep-the-last-value-of-a-duplicate-key
+    2.eq > @
+      get.
+        mp.found 1
+        "unreachable" > [message]
+    map * > mp
+      map.entry 1 1
+      map.entry 1 2
+
+  ++> can-rebuild-itself
+    2.eq mp.size > @
+    map * > mp
+      map.entry 1 1
+      map.entry 1 1
+      map.entry 2 1
+      map.entry 2 1
+
+  ++> can-rebuild-itself-only-once
+    1.eq > @
+      malloc.for
+        0
+        [m]
+          seq * > @
+            exists.
+              mp.found 1
+            exists.
+              mp.found 1
+            m
+          map * > mp
+            map.entry
+              m.put
+                m.as-number.plus 1
+              1
+
+  ++> can-remove-an-element-by-a-key
+    and. > @
+      1.eq mp.size
+      not.
+        mp.has "one"
+    without. > mp
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "one"
+
+  ++> can-remove-only-the-given-key-of-colliding-ones
+    and. > @
+      not.
+        mp.has "Aa"
+      mp.has "BB"
+    without. > mp
+      map *
+        map.entry "Aa" 1
+        map.entry "BB" 2
+      "Aa"
+
+  ++> can-replace-the-value-of-an-existing-key
+    and. > @
+      2.eq mp.size
+      3.eq
+        get.
+          mp.found "two"
+    with. > mp
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "two"
+      3
+
+  eq. ++> can-return-the-list-of-keys
+    keys.
+      map *
+        map.entry 1 2
+        map.entry 2 3
+        map.entry 3 4
+    *
+      1
+      2
+      3
+
+  eq. ++> can-return-the-list-of-values
+    values.
+      map *
+        map.entry 1 2
+        map.entry 2 3
+        map.entry 3 4
+    *
+      2
+      3
+      4
+
+  eq. ++> cannot-change-without-an-absent-element
+    size.
+      without.
+        map *
+          map.entry "one" 1
+        "two"
+    1
+
+  not. ++> cannot-find-an-element-by-an-absent-key
+    exists.
+      found.
+        map *
+          map.entry "one" 1
+          map.entry "two" 2
+        "three"
+
+  not. ++> cannot-have-an-absent-key-colliding-with-a-stored-one
+    has.
+      map *
+        map.entry "Aa" 1
+      "BB"
+
+  not. ++> cannot-have-an-element-by-an-absent-key
+    has.
+      map *
+        map.entry "one" 1
+        map.entry "two" 2
+      "three"
+
+  eq. ++> rejects-an-absent-key-colliding-with-a-stored-one
+    "recovered"
+    get.
+      found.
+        map *
+          map.entry "Aa" 1
+        "BB"
+      "recovered" > [message]
+
+  ++> rejects-getting-a-missing-key
+    "recovered".eq > @
+      get.
+        mp.found "absent"
+        "recovered" > [message]
+    map * > mp
+      map.entry "one" 1
+
+  --> stops-on-getting-a-missing-key
+    get. > @
+      mp.found "absent"
+    map * > mp
+      map.entry "one" 1

--- a/objects/mktemp.eo
+++ b/objects/mktemp.eo
@@ -1,0 +1,54 @@
+# Temporary directory.
+# For Unix/MacOS uses the path supplied by the first environment variable
+# found in the list TMPDIR, TMP, TEMP, TEMPDIR.
+# If none of these are found, "/tmp" is used.
+#
+# For Windows uses the path reported by the Windows "GetTempPath" API function which
+# takes the first environment variable in the list TMP, TEMP, USERPROFILE.
+# If none of these are found, it returns the Windows directory (C:\Windows).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > mktemp
+  directory > @
+    file
+      string
+        [] >>!
+          os.is-windows.if > @
+            if.
+              tmp.eq empty
+              if.
+                temp.eq empty
+                if.
+                  userprofile.eq empty
+                  "C:\\Windows"
+                  getenv "USERPROFILE" >> userprofile!
+                getenv "TEMP" >> temp!
+              getenv "TMP" >> tmp!
+            if.
+              tmpdir.eq empty
+              if.
+                tmp.eq empty
+                if.
+                  temp.eq empty
+                  if.
+                    tempdir.eq empty
+                    "/tmp"
+                    getenv "TEMPDIR" >> tempdir!
+                  temp
+                tmp
+              getenv "TMPDIR" >> tmpdir!
+          -- > empty
+
+  mktemp.tmpfile.exists ++> can-create-a-temp-file
+
+  mktemp.is-directory ++> can-point-at-a-global-temp-directory
+
+  mktemp.exists ++> can-point-at-an-existing-global-temp-directory
+
+  mktemp.path.eq mktemp.path ++> can-return-the-same-temp-directory

--- a/objects/nan.eo
+++ b/objects/nan.eo
@@ -1,10 +1,12 @@
+# Not-a-number (NaN) abstraction
+# for representing undefined or unrepresentable numerical results.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The `not a number` object is an abstraction
-# for representing undefined or unrepresentable numerical results.
-number 7F-F8-00-00-00-00-00-00 > nan
+number > nan
+  7F-F8-00-00-00-00-00-00

--- a/objects/ninf.eo
+++ b/objects/ninf.eo
@@ -1,11 +1,13 @@
+# Negative infinity.
+# A special floating-point value representing an unbounded quantity less than all real numbers.
+# When dataized, it signifies an unbounded lower limit or an unreachable minimum value.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# Negative infinity.
-# A special floating-point value representing an unbounded quantity less than all real numbers.
-# When dataized, it signifies an unbounded lower limit or an unreachable minimum value.
-number FF-F0-00-00-00-00-00-00 > ninf
+number > ninf
+  FF-F0-00-00-00-00-00-00

--- a/objects/nop.eo
+++ b/objects/nop.eo
@@ -1,30 +1,27 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-
-# The `nop` object is a no-operation: it ignores its argument and
+# No-operation object `nop`: it ignores its argument and
 # always behaves as TRUE. It is useful for temporarily disabling a
 # test (or any other dataizable expression) without removing the
 # code, by wrapping the original body inside `nop`:
 #
 # ```
-# [] +> works-just-fine
+# ++> can-work-just-fine
 #   nop > @
 #     "doesn't work for now"
 # ```
 #
 # The wrapped expression is not evaluated, and the surrounding test
 # passes trivially.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
 [x] > nop
   true > @
 
-  # Tests that nop ignores its argument and behaves as TRUE.
-  [] +> tests-nop-is-true
-    nop "anything" > @
+  nop 42 ++> accepts-a-number-argument
 
-  # Tests that nop returns TRUE regardless of the argument type.
-  [] +> tests-nop-with-number-is-true
-    nop 42 > @
+  nop "anything" ++> can-ignore-a-text-argument

--- a/objects/number.eo
+++ b/objects/number.eo
@@ -1,1459 +1,416 @@
+# Object `number` is an abstraction of a 64-bit floating-point
+# number that internally is a chain of eight bytes.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+rt jvm org.eolang:eo-runtime:0.61.3
++rt jvm org.eolang:eo-runtime:0.62.0
 +rt node eo2js-runtime:0.0.0
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint mandatory-package
 
-# The `number` object is an abstraction of a 64-bit floating-point
-# number that internally is a chain of eight bytes.
 [as-bytes] > number
   as-bytes > @
-  times -1 > neg
-  as-i64.as-i32 > as-i32
   as-i32.as-i16 > as-i16
-  as-bytes.eq 7F-F8-00-00-00-00-00-00 > is-nan
-  and. > is-integer
-    is-finite
-    eq floor
-  and. > is-finite
-    is-nan.not
-    not.
-      or.
-        as-bytes.eq 7F-F0-00-00-00-00-00-00
-        as-bytes.eq FF-F0-00-00-00-00-00-00
+  as-i32. > as-i32
+    number.as-i64 $
+  [] > div /Q.number
+    ? > x /Q.number
+  [] > gt /Q.bool
+    ? > x /Q.number
+  [] > plus /Q.number
+    ? > x /Q.number
+  [] > times /Q.number
+    ? > x /Q.number
 
-  # Convert this `org.eolang.number` to `org.eolang.i64` object and return it.
-  [] > as-i64 /i64
+  eq. ++> can-add-a-negative-float-to-negative-infinity
+    ninf.plus -42.5
+    ninf
 
-  # Returns true if this number equals `x` when compared as byte sequences.
-  # The parameter `x` can be a `number` or any object convertible to `bytes`
-  # via the `as-bytes` method. Follows IEEE 754 standard where negative zero
-  # (-0.0) and positive zero (0.0) are considered equal.
-  [x] > eq
-    if. > @
-      or.
-        is-nan
-        (number xbts).is-nan
-      false
-      or.
-        and.
-          or.
-            xbts.eq pzero
-            xbts.eq nzero
-          or.
-            bts.eq pzero
-            bts.eq nzero
-        bts.eq xbts
-    x > xbts!
-    as-bytes > bts!
-    0.as-bytes > pzero
-    -0.as-bytes > nzero
+  eq. ++> can-add-a-negative-integer-to-negative-infinity
+    ninf.plus -42
+    ninf
 
-  # Returns `true` if `$` < `x`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > lt
-    0.gt > @
-      minus
-        number value
-    x > value!
+  eq. ++> can-add-a-positive-float-to-negative-infinity
+    ninf.plus 42.5
+    ninf
 
-  # Returns `true` if `$` <= `x`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > lte
-    or. > @
-      lt value
-      eq value
-    x > value!
+  eq. ++> can-add-a-positive-float-to-positive-infinity
+    pinf.plus 42.5
+    pinf
 
-  # Returns `org.eolang.true` if `$` > `x`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > gt /bool
+  eq. ++> can-add-a-positive-integer-to-negative-infinity
+    ninf.plus 42
+    ninf
 
-  # Returns `true` if `$` >= `x`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > gte
-    or. > @
-      gt value
-      eq value
-    x > value!
+  eq. ++> can-add-nan-to-negative-infinity
+    as-bytes.
+      ninf.plus nan
+    nan.as-bytes
 
-  # Multiplication of `$` and `x` as `org.eolang.number`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > times /number
+  eq. ++> can-add-nan-to-positive-infinity
+    as-bytes.
+      pinf.plus nan
+    nan.as-bytes
 
-  # Sum of `$` and `x` as `org.eolang.number`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > plus /number
+  ninf.eq ++> can-add-negative-infinity-to-negative-infinity
+    ninf.plus ninf
 
-  # Difference between `$` and `x`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > minus
-    plus > @
-      (number value).neg
-    x > value!
+  eq. ++> can-add-negative-infinity-to-positive-infinity
+    as-bytes.
+      pinf.plus ninf
+    nan.as-bytes
 
-  # Quotient of the division of `$` by `x` as `org.eolang.number`.
-  # Here `x` can be a `number` or any other object which
-  # can be converted to 8 `bytes` via `as-bytes` object.
-  [x] > div /number
+  eq. ++> can-add-one-to-one
+    1.plus 1
+    2
 
-  # The object rounds down the original `number` to the nearest
-  # whole `number` that is less than or equal to it
-  # and returns the result as `org.eolang.number`.
-  # For non-finite values (`nan`, `+inf`, `-inf`) the input is returned
-  # unchanged. For finite inputs we truncate toward zero via `as-i64`,
-  # which matches mathematical floor for every value except negative
-  # non-integers - where the truncated result is strictly greater than
-  # the original, so we subtract `1` in that single case.
-  [] > floor
-    if. > @
-      or.
-        ^.is-finite.not
-        or.
-          ^.gte 4503599627370496
-          ^.lte -4503599627370496
-      ^
-      if.
-        trunc.gt ^
-        trunc.minus 1
-        trunc
-    ^.as-i64.as-number > trunc
+  eq. ++> can-add-positive-infinity-to-negative-infinity
+    as-bytes.
+      ninf.plus pinf
+    nan.as-bytes
 
-  # Tests that less-than comparison returns true when first number is smaller.
-  [] +> tests-int-less-true
-    lt. > @
-      10
-      50
+  eq. ++> can-add-positive-infinity-to-positive-infinity
+    pinf.plus pinf
+    pinf
 
-  # Tests that less-than comparison returns false when numbers are equal.
-  [] +> tests-int-less-equal
-    eq. > @
-      not.
-        lt.
-          10
-          10
-      true
+  lt. ++> can-approximate-a-square-root
+    abs.
+      9.sqrt.minus 3
+    1.0E-9
 
-  # Tests that less-than comparison returns false when first number is greater.
-  [] +> tests-int-less-false
-    eq. > @
-      not.
-        lt.
-          10
-          -5
-      true
+  pinf.gt 42.5 ++> can-be-greater-than-a-float-when-positive-infinity
 
-  # Tests that greater-than comparison returns true when first number is larger.
-  [] +> tests-int-greater-true
-    eq. > @
-      gt.
-        -200
-        -1000
-      true
+  eq. ++> can-be-greater-than-a-smaller-integer
+    -200.gt -1000
+    true
 
-  # Tests that greater-than comparison returns false when first number is smaller.
-  [] +> tests-int-greater-false
-    eq. > @
-      not.
-        gt.
-          0
-          100
-      true
+  pinf.gt 42 ++> can-be-greater-than-an-integer-when-positive-infinity
 
-  # Tests that greater-than comparison returns false when numbers are equal.
-  [] +> tests-int-greater-equal
-    eq. > @
-      not.
-        gt.
-          0
-          0
-      true
+  pinf.gt ninf ++> can-be-greater-than-negative-infinity-when-positive-infinity
 
-  # Tests that less-than-or-equal comparison returns true when first number is smaller.
-  [] +> tests-int-leq-true
-    eq. > @
-      lte.
-        -200
-        -100
-      true
-
-  # Tests that less-than-or-equal comparison returns true when numbers are equal.
-  [] +> tests-int-leq-equal
-    eq. > @
-      lte.
-        50
-        50
-      true
-
-  # Tests that less-than-or-equal comparison returns false when first number is greater.
-  [] +> tests-int-leq-false
-    eq. > @
-      not.
-        lte.
-          0
-          -10
-      true
-
-  # Tests that greater-than-or-equal comparison returns true when first number is larger.
-  [] +> tests-int-gte-true
-    eq. > @
-      gte.
-        -1000
-        -1100
-      true
-
-  # Tests that greater-than-or-equal comparison returns true when numbers are equal.
-  [] +> tests-int-gte-equal
-    eq. > @
-      gte.
-        113
-        113
-      true
-
-  # Tests that greater-than-or-equal comparison returns false when first number is smaller.
-  [] +> tests-int-gte-false
-    eq. > @
-      not.
-        gte.
-          0
-          10
-      true
-
-  # Tests that equality comparison with NaN and infinity values returns false.
-  [] +> tests-int-equal-to-nan-and-infinites-is-false
-    eq. > @
-      and.
-        and.
-          and.
-            and.
-              and.
-                (0.eq nan).eq false
-                (0.eq pinf).eq false
-              (0.eq ninf).eq false
-            (42.eq nan).eq false
-          (42.eq pinf).eq false
-        (42.eq ninf).eq false
-      true
-
-  # Tests that one zero value equals another zero value.
-  [] +> tests-int-zero-eq-to-zero
-    eq. > @
-      eq.
-        0
-        0
-      true
-
-  # Tests that integer zero equals floating-point zero.
-  [] +> tests-int-zero-eq-to-float-zero
-    eq. > @
-      eq.
-        0
-        0.0
-      true
-
-  # Tests that equality comparison returns true for identical numbers.
-  [] +> tests-int-eq-true
-    eq. > @
-      eq.
-        123
-        123
-      true
-
-  # Tests that equality comparison returns false for different numbers.
-  [] +> tests-int-eq-false
-    eq. > @
-      not.
-        eq.
-          123
-          42
-      true
-
-  # Tests that addition works correctly with simple numbers.
-  [] +> tests-one-plus-one
-    eq. > @
-      1.plus 1
-      2
-
-  # Tests that subtraction works correctly with simple numbers.
-  [] +> tests-one-minus-one
-    eq. > @
-      1.minus 1
-      0
-
-  # Tests that equality comparison returns false for different data types.
-  [] +> tests-compares-two-different-number-types
-    eq. > @
-      68.eq "12345678"
-      false
-
-  # Tests that recursive Fibonacci calculation works correctly.
-  [] +> tests-calculates-fibonacci-number-with-recursion
-    eq. > @
-      fibo 4
-      3
-    # Recursively calculates Fibonacci number for given n.
-    [n] > fibo
-      if. > @
-        n.lt 3
-        1
-        plus.
-          fibo (n.minus 1)
-          fibo (n.minus 2)
-
-  # Tests that tail-recursive Fibonacci calculation works correctly.
-  [] +> tests-calculates-fibonacci-number-with-tail
+  ++> can-calculate-fibonacci-with-a-tail-call
     eq. > @
       fibonacci 4
       3
-
-    # Calculates Fibonacci number using tail recursion for efficiency.
     [n] > fibonacci
       if. > @
         n.lt 3
         small n
-        rec n 1 1
-
-      # Handles small Fibonacci numbers (n less than 3) as base case.
-      [n] > small
-        if. > @
-          n.eq 2
-          1
-          n
-
-      # Tail recursive helper accumulating Fibonacci values down to base.
-      [n minus1 minus2] > rec
-        if. > @
+        if. > [n minus1 minus2] >> rec
           n.eq 3
           minus1.plus minus2
-          rec (n.minus 1) (minus1.plus minus2) minus1
+          rec
+            n.minus 1
+            minus1.plus minus2
+            minus1
+        | n 1 1
+      if. > [n] > small
+        n.eq 2
+        1
+        n
 
-  # Checks that division by zero does not return an error object.
-  [] +> tests-zero-division
-    try > @
-      seq
-        *
-          2.div 0
-          true
-      false > [e]
-      false
+  ++> can-calculate-fibonacci-with-recursion
+    eq. > @
+      fibo 4
+      3
+    if. > [n] > fibo
+      n.lt 3
+      1
+      plus.
+        fibo
+          n.minus 1
+        fibo
+          n.minus 2
 
-  # Checks that division by one returns the dividend.
-  [] +> tests-division-by-one
+  42.as-bytes.eq 42 ++> can-compare-its-bytes-to-an-integer
+
+  42.as-bytes.eq 42 ++> can-convert-to-bytes-and-back
+
+  eq. ++> can-divide-a-positive-dividend
+    256.div 16
+    16
+
+  ++> can-divide-by-one
     eq. > @
       dividend.div 1
       dividend
     -235 > dividend
 
-  # Tests that division works properly with positive dividends.
-  [] +> tests-div-for-dividend-greater-than-zero
-    eq. > @
-      256.div 16
-      16
-
-  # Tests that division with remainder produces correct floor result.
-  [] +> tests-div-with-remainder
-    eq. > @
-      floor.
-        13.div -5
-      -3
-
-  # Tests that floor of a positive fractional number truncates toward zero.
-  [] +> tests-floor-positive-fraction
-    eq. > @
-      3.7.floor
-      3
-
-  # Tests that floor of a negative fractional number rounds toward negative infinity.
-  [] +> tests-floor-negative-fraction
-    eq. > @
-      -3.7.floor
-      -4
-
-  # Tests that floor of a small negative fractional number rounds toward negative infinity.
-  [] +> tests-floor-negative-small-fraction
-    eq. > @
-      -0.1.floor
-      -1
-
-  # Tests that floor of a whole number returns the same number.
-  [] +> tests-floor-of-integer
-    eq. > @
-      42.floor
-      42
-
-  # Tests that floor of a negative whole number returns the same number.
-  [] +> tests-floor-of-negative-integer
-    eq. > @
-      -5.floor
-      -5
-
-  # Tests that floor of a very large positive number >= 2^52 returns itself.
-  [] +> tests-floor-of-large-positive-integer
-    eq. > @
-      100000000000000000000.floor
-      100000000000000000000
-
-  # Tests that floor of a very large negative number <= -2^52 returns itself.
-  [] +> tests-floor-of-large-negative-integer
-    eq. > @
-      -100000000000000000000.floor
-      -100000000000000000000
-
-  # Tests that floor of zero returns zero.
-  [] +> tests-floor-of-zero
-    eq. > @
-      0.floor
-      0
-
-  # Tests that division result can be less than one.
-  [] +> tests-div-less-than-one
-    lt. > @
-      1.div 5
-      1
-
-  # Tests that number to bytes conversion works correctly.
-  [] +> tests-to-bytes-and-backwards
-    eq. > @
-      as-bytes.
-        42
-      42
-
-  # Tests that number equals its byte representation.
-  [] +> tests-as-bytes-equals-to-int
-    eq. > @
-      42
-      42.as-bytes
-
-  # Tests that byte representation equals original number.
-  [] +> tests-as-bytes-equals-to-int-backwards
-    eq. > @
-      42.as-bytes
-      42
-
-  # Tests that multiplication by zero returns zero.
-  [] +> tests-multiply-by-zero
-    eq. > @
-      1000.times 0
-      0
-
-  # Tests that a simple number is not NaN.
-  [] +> tests-simple-number-is-not-nan
-    42.5.is-nan.not > @
-
-  # Tests that an integer number is detected as integer.
-  32.is-integer > [] +> int-number-is-integer
-
-  # Tests that a floating-point number is not detected as integer.
-  32.5.is-integer.not > [] +> float-number-is-not-integer
-
-  # Tests that a simple number is finite.
-  32.is-finite > [] +> simple-number-is-finite
-
-  # Tests that a number created with NaN bytes is detected as NaN.
-  [] +> tests-number-with-nan-bytes-is-nan
-    (number nan.as-bytes).is-nan > @
-
-  # Tests that a number created with infinite bytes is not finite.
-  [] +> tests-number-with-infinite-bytes-is-not-finite
-    (number pinf.as-bytes).is-finite.not > @
-
-  # Equal to.
-  # Tests that positive infinity equals one divided by zero.
-  [] +> tests-positive-infinity-is-equal-to-one-div-zero
-    eq. > @
-      pinf
-      1.0.div 0.0
-
-  # Tests that positive infinity equals positive infinity.
-  [] +> tests-positive-infinity-eq-positive-infinity
-    eq. > @
-      pinf
-      pinf
-
-  # Tests that positive infinity is not equal to negative infinity.
-  [] +> tests-positive-infinity-not-eq-negative-infinity
-    not. > @
-      eq.
-        pinf
-        ninf
-
-  # Tests that positive infinity is not equal to NaN.
-  [] +> tests-positive-infinity-not-eq-nan
-    not. > @
-      eq.
-        pinf
-        nan
-
-  # Tests that positive infinity is not equal to an integer.
-  [] +> tests-positive-infinity-not-eq-int
-    not. > @
-      eq.
-        pinf
-        42
-
-  # Tests that positive infinity is not equal to a float.
-  [] +> tests-positive-infinity-not-eq-float
-    not. > @
-      eq.
-        pinf
-        42.5
-
-  # Less than.
-  # Tests that positive infinity is not less than positive infinity.
-  [] +> tests-positive-infinity-lt-positive-infinity
-    eq. > @
-      pinf.lt pinf
-      false
-
-  # Tests that positive infinity is not less than negative infinity.
-  [] +> tests-positive-infinity-not-lt-negative-infinity
-    eq. > @
-      pinf.lt ninf
-      false
-
-  # Tests that positive infinity is not less than NaN.
-  [] +> tests-positive-infinity-not-lt-nan
-    eq. > @
-      pinf.lt nan
-      false
-
-  # Tests that positive infinity is not less than an integer.
-  [] +> tests-positive-infinity-not-lt-int
-    eq. > @
-      pinf.lt 42
-      false
-
-  # Tests that positive infinity is not less than a float.
-  [] +> tests-positive-infinity-not-lt-float
-    eq. > @
-      pinf.lt 42.5
-      false
-
-  # Less or equal than.
-  # Tests that positive infinity is less than or equal to positive infinity.
-  [] +> tests-positive-infinity-lte-positive-infinity
-    eq. > @
-      pinf.lte pinf
-      true
-
-  # Tests that positive infinity is not less than or equal to negative infinity.
-  [] +> tests-positive-infinity-not-lte-negative-infinity
-    eq. > @
-      pinf.lte ninf
-      false
-
-  # Tests that positive infinity is not less than or equal to NaN.
-  [] +> tests-positive-infinity-not-lte-nan
-    eq. > @
-      pinf.lte nan
-      false
-
-  # Tests that positive infinity is not less than or equal to an integer.
-  [] +> tests-positive-infinity-not-lte-int
-    eq. > @
-      pinf.lte 42
-      false
-
-  # Tests that positive infinity is not less than or equal to a float.
-  [] +> tests-positive-infinity-not-lte-float
-    eq. > @
-      pinf.lte 42.5
-      false
-
-  # Greater than.
-  # Tests that positive infinity is not greater than positive infinity.
-  [] +> tests-positive-infinity-gt-positive-infinity
-    not. > @
-      gt.
-        pinf
-        pinf
-
-  # Tests that positive infinity is greater than negative infinity.
-  [] +> tests-positive-infinity-gt-negative-infinity
-    gt. > @
-      pinf
-      ninf
-
-  # Tests that positive infinity is not greater than NaN.
-  [] +> tests-positive-infinity-not-gt-nan
-    not. > @
-      gt.
-        pinf
-        nan
-
-  # Tests that positive infinity is greater than an integer.
-  [] +> tests-positive-infinity-gt-int
-    gt. > @
-      pinf
-      42
-
-  # Tests that positive infinity is greater than a float.
-  [] +> tests-positive-infinity-gt-float
-    gt. > @
-      pinf
-      42.5
-
-  # Greater or equal than.
-  # Tests that positive infinity is greater than or equal to positive infinity.
-  [] +> tests-positive-infinity-gte-positive-infinity
-    eq. > @
-      pinf.gte pinf
-      true
-
-  # Tests that positive infinity is greater than or equal to negative infinity.
-  [] +> tests-positive-infinity-gte-negative-infinity
-    eq. > @
-      pinf.gte ninf
-      true
-
-  # Tests that positive infinity is not greater than or equal to NaN.
-  [] +> tests-positive-infinity-not-gte-nan
-    eq. > @
-      pinf.gte nan
-      false
-
-  # Tests that positive infinity is greater than or equal to an integer.
-  [] +> tests-positive-infinity-gte-int
-    eq. > @
-      pinf.gte 42
-      true
-
-  # Tests that positive infinity is greater than or equal to a float.
-  [] +> tests-positive-infinity-gte-float
-    eq. > @
-      pinf.gte 42.5
-      true
-
-  # Tests that float comparison with NaN and infinities returns false under high load.
-  [] +> tests-float-equal-to-nan-and-infinites-is-false-highload
-    eq. > @
-      and.
-        and.
-          and.
-            and.
-              and.
-                and.
-                  and.
-                    and.
-                      and.
-                        and.
-                          and.
-                            (0.0.eq nan).eq false
-                            (0.0.eq pinf).eq false
-                          (0.0.eq ninf).eq false
-                        (42.5.eq nan).eq false
-                      (42.5.eq pinf).eq false
-                    (42.5.eq ninf).eq false
-                  (0.0.eq nan).eq false
-                (0.0.eq pinf).eq false
-              (0.0.eq ninf).eq false
-            (42.5.eq nan).eq false
-          (42.5.eq pinf).eq false
-        (42.5.eq ninf).eq false
-      true
-
-  # Times.
-  # Tests that positive infinity times float zero returns NaN.
-  [] +> tests-positive-infinity-times-float-zero
-    eq. > @
-      as-bytes.
-        pinf.times 0.0
-      nan.as-bytes
-
-  # Tests that positive infinity times negative float zero returns NaN.
-  [] +> tests-positive-infinity-times-neg-float-zero
-    eq. > @
-      as-bytes.
-        pinf.times -0.0
-      nan.as-bytes
-
-  # Tests that positive infinity times integer zero returns NaN.
-  [] +> tests-positive-infinity-times-int-zero
-    eq. > @
-      as-bytes.
-        pinf.times 0
-      nan.as-bytes
-
-  # Tests that positive infinity times NaN returns NaN.
-  [] +> tests-positive-infinity-times-nan
-    eq. > @
-      as-bytes.
-        pinf.times nan
-      nan.as-bytes
-
-  # Tests that positive infinity times negative infinity returns negative infinity.
-  [] +> tests-positive-infinity-times-negative-infinity
-    eq. > @
-      pinf.times ninf
-      ninf
-
-  # Tests that positive infinity times positive infinity returns positive infinity.
-  [] +> tests-positive-infinity-times-positive-infinity
-    eq. > @
-      pinf.times pinf
-      pinf
-
-  # Tests that positive infinity times a positive float returns positive infinity.
-  [] +> tests-positive-infinity-times-positive-float
-    eq. > @
-      pinf.times 42.5
-      pinf
-
-  # Tests that positive infinity times a positive integer returns positive infinity.
-  [] +> tests-positive-infinity-times-positive-int
-    eq. > @
-      pinf.times 42
-      pinf
-
-  # Tests that positive infinity times a negative float returns negative infinity.
-  [] +> tests-positive-infinity-times-negative-float
-    eq. > @
-      pinf.times -42.5
-      ninf
-
-  # Tests that positive infinity times a negative integer returns negative infinity.
-  [] +> tests-positive-infinity-times-negative-int
-    eq. > @
-      pinf.times -42
-      ninf
-
-  # Plus
-  # Tests that positive infinity plus NaN returns NaN.
-  [] +> tests-positive-infinity-plus-nan
-    eq. > @
-      as-bytes.
-        pinf.plus nan
-      nan.as-bytes
-
-  # Tests that positive infinity plus negative infinity returns NaN.
-  [] +> tests-positive-infinity-plus-negative-infinity
-    eq. > @
-      as-bytes.
-        pinf.plus ninf
-      nan.as-bytes
-
-  # Tests that positive infinity plus positive infinity returns positive infinity.
-  [] +> tests-positive-infinity-plus-positive-infinity
-    eq. > @
-      pinf.plus pinf
-      pinf
-
-  # Tests that positive infinity plus a positive float returns positive infinity.
-  [] +> tests-positive-infinity-plus-positive-float
-    eq. > @
-      pinf.plus 42.5
-      pinf
-
-  # Negation
-  # Tests that negation of positive infinity returns negative infinity.
-  [] +> tests-positive-infinity-neg-is-negative-infinity
-    eq. > @
-      pinf.neg
-      ninf
-
-  # Minus
-  # Tests that positive infinity minus NaN returns NaN.
-  [] +> tests-positive-infinity-minus-nan
-    eq. > @
-      as-bytes.
-        pinf.minus nan
-      nan.as-bytes
-
-  # Tests that positive infinity minus positive infinity returns NaN.
-  [] +> tests-positive-infinity-minus-positive-infinity
-    eq. > @
-      as-bytes.
-        pinf.minus pinf
-      nan.as-bytes
-
-  # Tests that positive infinity minus negative infinity returns positive infinity.
-  [] +> tests-positive-infinity-minus-negative-infinity
-    eq. > @
-      pinf.minus ninf
-      pinf
-
-  # Tests that positive infinity minus a positive float returns positive infinity.
-  [] +> tests-positive-infinity-minus-positive-float
-    eq. > @
-      pinf.minus 42.5
-      pinf
-
-  # Tests that positive infinity minus a positive integer returns positive infinity.
-  [] +> tests-positive-infinity-minus-positive-int
-    eq. > @
-      pinf.minus 42
-      pinf
-
-  # Tests that positive infinity minus a negative float returns positive infinity.
-  [] +> tests-positive-infinity-minus-negative-float
-    eq. > @
-      pinf.minus -42.5
-      pinf
-
-  # Tests that positive infinity minus a negative integer returns positive infinity.
-  [] +> tests-positive-infinity-minus-negative-int
-    eq. > @
-      pinf.minus -42
-      pinf
-
-  # Division
-  # Tests that positive infinity divided by float zero returns positive infinity.
-  [] +> tests-positive-infinity-div-float-zero
-    eq. > @
-      pinf.div 0.0
-      pinf
-
-  # Tests that positive infinity divided by negative float zero returns negative infinity.
-  [] +> tests-positive-infinity-div-neg-float-zero
-    eq. > @
-      pinf.div -0.0
-      ninf
-
-  # Tests that positive infinity divided by integer zero returns positive infinity.
-  [] +> tests-positive-infinity-div-int-zero
-    eq. > @
-      pinf.div 0
-      pinf
-
-  # Tests that positive infinity divided by negative integer zero returns negative infinity.
-  [] +> tests-positive-infinity-div-neg-int-zero
-    eq. > @
-      pinf.div -0
-      ninf
-
-  # Tests that positive infinity divided by NaN returns NaN.
-  [] +> tests-positive-infinity-div-nan
-    eq. > @
-      as-bytes.
-        pinf.div nan
-      nan.as-bytes
-
-  # Tests that positive infinity divided by negative infinity returns NaN.
-  [] +> tests-positive-infinity-div-negative-infinity
-    eq. > @
-      as-bytes.
-        pinf.div ninf
-      nan.as-bytes
-
-  # Tests that positive infinity divided by positive infinity returns NaN.
-  [] +> tests-positive-infinity-div-positive-infinity
-    eq. > @
-      as-bytes.
-        pinf.div pinf
-      nan.as-bytes
-
-  # Tests that positive infinity divided by a positive float returns positive infinity.
-  [] +> tests-positive-infinity-div-positive-float
-    eq. > @
-      pinf.div 42.5
-      pinf
-
-  # Tests that positive infinity divided by a positive integer returns positive infinity.
-  [] +> tests-positive-infinity-div-positive-int
-    eq. > @
-      pinf.div 42
-      pinf
-
-  # Tests that positive infinity divided by a negative float returns negative infinity.
-  [] +> tests-positive-infinity-div-negative-float
-    eq. > @
-      pinf.div -42.5
-      ninf
-
-  # Tests that positive infinity divided by a negative integer returns negative infinity.
-  [] +> tests-positive-infinity-div-negative-int
-    eq. > @
-      pinf.div -42
-      ninf
-
-  # Bytes.
-  # Tests that positive infinity as bytes equals one divided by zero as bytes.
-  [] +> tests-positive-infinity-as-bytes-is-valid
-    eq. > @
-      pinf.as-bytes
-      (1.0.div 0.0).as-bytes
-
-  # Tests that positive infinity floor equals itself.
-  [] +> tests-positive-infinity-floor-is-equal-to-self
-    pinf.floor.eq pinf > @
-
-  # Tests that positive infinity is not NaN.
-  [] +> tests-positive-infinity-is-not-nan
-    pinf.is-nan.not > @
-
-  # Tests that positive infinity is not finite.
-  [] +> tests-positive-infinity-is-not-finite
-    pinf.is-finite.not > @
-
-  # Tests that positive infinity is not an integer.
-  [] +> tests-positive-infinity-is-not-integer
-    pinf.is-integer.not > @
-
-  # Equal to.
-  # Tests that negative infinity equals negative one divided by zero.
-  [] +> tests-negative-infinity-is-equal-to-one-div-zero
-    eq. > @
-      ninf
-      -1.0.div 0.0
-
-  # Tests that negative infinity equals negative infinity.
-  [] +> tests-negative-infinity-eq-negative-infinity
-    eq. > @
-      ninf
-      ninf
-
-  # Tests that negative infinity is not equal to positive infinity.
-  [] +> tests-negative-infinity-not-eq-positive-infinity
-    not. > @
-      eq.
-        ninf
-        pinf
-
-  # Tests that negative infinity is not equal to NaN.
-  [] +> tests-negative-infinity-not-eq-nan
-    not. > @
-      eq.
-        ninf
-        nan
-
-  # Tests that negative infinity is not equal to an integer.
-  [] +> tests-negative-infinity-not-eq-int
-    not. > @
-      eq.
-        ninf
-        42
-
-  # Tests that negative infinity is not equal to a float.
-  [] +> tests-negative-infinity-not-eq-float
-    not. > @
-      eq.
-        ninf
-        42.5
-
-  # Less than.
-  # Tests that negative infinity is not less than negative infinity.
-  [] +> tests-negative-infinity-lt-negative-infinity
-    eq. > @
-      ninf.lt ninf
-      false
-
-  # Tests that negative infinity is less than positive infinity.
-  [] +> tests-negative-infinity-lt-positive-infinity
-    eq. > @
-      ninf.lt pinf
-      true
-
-  # Tests that negative infinity is not less than NaN.
-  [] +> tests-negative-infinity-not-lt-nan
-    eq. > @
-      ninf.lt nan
-      false
-
-  # Tests that negative infinity is less than an integer.
-  [] +> tests-negative-infinity-lt-int
-    lt. > @
-      ninf
-      42
-
-  # Tests that negative infinity is less than a float.
-  [] +> tests-negative-infinity-lt-float
-    lt. > @
-      ninf
-      42.5
-
-  # Less or equal than.
-  # Tests that negative infinity is less than or equal to negative infinity.
-  [] +> tests-negative-infinity-lte-negative-infinity
-    eq. > @
-      ninf.lte ninf
-      true
-
-  # Tests that negative infinity is less than or equal to positive infinity.
-  [] +> tests-negative-infinity-lte-positive-infinity
-    eq. > @
-      ninf.lte pinf
-      true
-
-  # Tests that negative infinity is not less than or equal to NaN.
-  [] +> tests-negative-infinity-not-lte-nan
-    eq. > @
-      ninf.lte nan
-      false
-
-  # Tests that negative infinity is less than or equal to an integer.
-  [] +> tests-negative-infinity-lte-int
-    eq. > @
-      ninf.lte 42
-      true
-
-  # Tests that negative infinity is less than or equal to a float.
-  [] +> tests-negative-infinity-lte-float
-    eq. > @
-      ninf.lte 42.5
-      true
-
-  # Greater than.
-  # Tests that negative infinity is not greater than negative infinity.
-  [] +> tests-negative-infinity-gt-negative-infinity
-    not. > @
-      gt.
-        ninf
-        ninf
-
-  # Tests that negative infinity is not greater than positive infinity.
-  [] +> tests-negative-infinity-not-gt-positive-infinity
-    eq. > @
-      ninf.gt pinf
-      false
-
-  # Tests that negative infinity is not greater than NaN.
-  [] +> tests-negative-infinity-not-gt-nan
-    eq. > @
-      ninf.gt nan
-      false
-
-  # Tests that negative infinity is not greater than an integer.
-  [] +> tests-negative-infinity-not-gt-int
-    eq. > @
-      ninf.gt 42
-      false
-
-  # Tests that negative infinity is not greater than a float.
-  [] +> tests-negative-infinity-not-gt-float
-    eq. > @
-      ninf.gt 42.5
-      false
-
-  # Greater or equal than.
-  # Tests that negative infinity is greater than or equal to negative infinity.
-  [] +> tests-negative-infinity-gte-negative-infinity
-    eq. > @
-      ninf.gte ninf
-      true
-
-  # Tests that negative infinity is not greater than or equal to positive infinity.
-  [] +> tests-negative-infinity-not-gte-positive-infinity
-    eq. > @
-      ninf.gte pinf
-      false
-
-  # Tests that negative infinity is not greater than or equal to NaN.
-  [] +> tests-negative-infinity-not-gte-nan
-    eq. > @
-      ninf.gte nan
-      false
-
-  # Tests that negative infinity is not greater than or equal to an integer.
-  [] +> tests-negative-infinity-not-gte-int
-    eq. > @
-      ninf.gte 42
-      false
-
-  # Tests that negative infinity is not greater than or equal to a float.
-  [] +> tests-negative-infinity-not-gte-float
-    eq. > @
-      ninf.gte 42.5
-      false
-
-  # Times.
-  # Tests that negative infinity times float zero returns NaN.
-  [] +> tests-negative-infinity-times-float-zero
-    eq. > @
-      as-bytes.
-        ninf.times 0.0
-      nan.as-bytes
-
-  # Tests that negative infinity times negative float zero returns NaN.
-  [] +> tests-negative-infinity-times-neg-float-zero
-    eq. > @
-      as-bytes.
-        ninf.times -0.0
-      nan.as-bytes
-
-  # Tests that negative infinity times integer zero returns NaN.
-  [] +> tests-negative-infinity-times-int-zero
-    eq. > @
-      as-bytes.
-        ninf.times 0
-      nan.as-bytes
-
-  # Tests that negative infinity times NaN returns NaN.
-  [] +> tests-negative-infinity-times-nan
-    eq. > @
-      as-bytes.
-        ninf.times nan
-      nan.as-bytes
-
-  # Tests that negative infinity times positive infinity returns negative infinity.
-  [] +> tests-negative-infinity-times-positive-infinity
-    eq. > @
-      ninf.times pinf
-      ninf
-
-  # Tests that negative infinity times negative infinity returns positive infinity.
-  [] +> tests-negative-infinity-times-negative-infinity
-    eq. > @
-      ninf.times ninf
-      pinf
-
-  # Tests that negative infinity times a positive float returns negative infinity.
-  [] +> tests-negative-infinity-times-positive-float
-    eq. > @
-      ninf.times 42.5
-      ninf
-
-  # Tests that negative infinity times a positive integer returns negative infinity.
-  [] +> tests-negative-infinity-times-positive-int
-    eq. > @
-      ninf.times 42
-      ninf
-
-  # Tests that negative infinity times a negative float returns positive infinity.
-  [] +> tests-negative-infinity-times-negative-float
-    eq. > @
-      ninf.times -42.5
-      pinf
-
-  # Tests that negative infinity times a negative integer returns positive infinity.
-  [] +> tests-negative-infinity-times-negative-int
-    eq. > @
-      ninf.times -42
-      pinf
-
-  # Plus.
-  # Tests that negative infinity plus NaN returns NaN.
-  [] +> tests-negative-infinity-plus-nan
-    eq. > @
-      as-bytes.
-        ninf.plus nan
-      nan.as-bytes
-
-  # Tests that negative infinity plus positive infinity returns NaN.
-  [] +> tests-negative-infinity-plus-positive-infinity
-    eq. > @
-      as-bytes.
-        ninf.plus pinf
-      nan.as-bytes
-
-  # Tests that negative infinity plus negative infinity returns negative infinity.
-  [] +> tests-negative-infinity-plus-negative-infinity
-    eq. > @
-      ninf
-      ninf.plus ninf
-
-  # Tests that negative infinity plus a positive float returns negative infinity.
-  [] +> tests-negative-infinity-plus-positive-float
-    eq. > @
-      ninf.plus 42.5
-      ninf
-
-  # Tests that negative infinity plus a positive integer returns negative infinity.
-  [] +> tests-negative-infinity-plus-positive-int
-    eq. > @
-      ninf.plus 42
-      ninf
-
-  # Tests that negative infinity plus a negative float returns negative infinity.
-  [] +> tests-negative-infinity-plus-negative-float
-    eq. > @
-      ninf.plus -42.5
-      ninf
-
-  # Tests that negative infinity plus a negative integer returns negative infinity.
-  [] +> tests-negative-infinity-plus-negative-int
-    eq. > @
-      ninf.plus -42
-      ninf
-
-  # Negation.
-  # Tests that negation of negative infinity returns positive infinity.
-  [] +> tests-negative-infinity-neg-is-positive-infinity
-    eq. > @
-      ninf.neg
-      pinf
-
-  # Minus.
-  # Tests that negative infinity minus NaN returns NaN.
-  [] +> tests-negative-infinity-minus-nan
-    eq. > @
-      as-bytes.
-        ninf.minus nan
-      nan.as-bytes
-
-  # Tests that negative infinity minus negative infinity returns NaN.
-  [] +> tests-negative-infinity-minus-negative-infinity
-    eq. > @
-      as-bytes.
-        ninf.minus ninf
-      nan.as-bytes
-
-  # Tests that negative infinity minus positive infinity returns negative infinity.
-  [] +> tests-negative-infinity-minus-positive-infinity
-    eq. > @
-      ninf.minus pinf
-      ninf
-
-  # Tests that negative infinity minus a positive float returns negative infinity.
-  [] +> tests-negative-infinity-minus-positive-float
-    eq. > @
-      ninf.minus 42.5
-      ninf
-
-  # Tests that negative infinity minus a positive integer returns negative infinity.
-  [] +> tests-negative-infinity-minus-positive-int
-    eq. > @
-      ninf.minus 42
-      ninf
-
-  # Tests that negative infinity minus a negative float returns negative infinity.
-  [] +> tests-negative-infinity-minus-negative-float
-    eq. > @
-      ninf.minus -42.5
-      ninf
-
-  # Tests that negative infinity minus a negative integer returns negative infinity.
-  [] +> tests-negative-infinity-minus-negative-int
-    eq. > @
-      ninf.minus -42
-      ninf
-
-  # Division.
-  # Tests that negative infinity divided by float zero returns negative infinity.
-  [] +> tests-negative-infinity-div-float-zero
-    eq. > @
-      ninf.div 0.0
-      ninf
-
-  # Tests that negative infinity divided by negative float zero returns positive infinity.
-  [] +> tests-negative-infinity-div-neg-float-zero
-    eq. > @
-      ninf.div -0.0
-      pinf
-
-  # Tests that negative infinity divided by integer zero returns negative infinity.
-  [] +> tests-negative-infinity-div-int-zero
-    eq. > @
-      ninf.div 0
-      ninf
-
-  # Tests that negative infinity divided by negative integer zero returns positive infinity.
-  [] +> tests-negative-infinity-div-neg-int-zero
-    eq. > @
-      ninf.div -0
-      pinf
-
-  # Tests that negative infinity divided by NaN returns NaN.
-  [] +> tests-negative-infinity-div-nan
-    eq. > @
-      as-bytes.
-        ninf.div nan
-      nan.as-bytes
-
-  # Tests that negative infinity divided by positive infinity returns NaN.
-  [] +> tests-negative-infinity-div-positive-infinity
-    eq. > @
-      as-bytes.
-        ninf.div pinf
-      nan.as-bytes
-
-  # Tests that negative infinity divided by negative infinity returns NaN.
-  [] +> tests-negative-infinity-div-negative-infinity
-    eq. > @
-      as-bytes.
-        ninf.div ninf
-      nan.as-bytes
-
-  # Tests that negative infinity divided by a positive float returns negative infinity.
-  [] +> tests-negative-infinity-div-positive-float
-    eq. > @
-      ninf.div 42.5
-      ninf
-
-  # Tests that negative infinity divided by a positive integer returns negative infinity.
-  [] +> tests-negative-infinity-div-positive-int
-    eq. > @
-      ninf.div 42
-      ninf
-
-  # Tests that negative infinity divided by a negative float returns positive infinity.
-  [] +> tests-negative-infinity-div-negative-float
-    eq. > @
-      ninf.div -42.5
-      pinf
-
-  # Tests that negative infinity divided by a negative integer returns positive infinity.
-  [] +> tests-negative-infinity-div-negative-int
-    eq. > @
-      ninf.div -42
-      pinf
-
-  # Bytes.
-  # Tests that negative infinity as bytes equals negative one divided by zero as bytes.
-  [] +> tests-negative-infinity-as-bytes-is-valid
-    eq. > @
-      ninf.as-bytes
-      (-1.0.div 0.0).as-bytes
-
-  # Tests that negative infinity floor equals itself.
-  [] +> tests-negative-infinity-floor-is-equal-to-self
-    ninf.floor.eq ninf > @
-
-  # Tests that negative infinity is not NaN.
-  [] +> tests-negative-infinity-is-not-nan
-    ninf.is-nan.not > @
-
-  # Tests that negative infinity is not finite.
-  [] +> tests-negative-infinity-is-not-finite
-    ninf.is-finite.not > @
-
-  # Tests that negative infinity is not an integer.
-  [] +> tests-negative-infinity-is-not-integer
-    ninf.is-integer.not > @
-
-  # Tests that NaN is not equal to a number.
-  [] +> tests-nan-not-eq-number
-    not. > @
-      eq.
-        nan
-        42
-
-  # Tests that NaN is not equal to NaN.
-  [] +> tests-nan-not-eq-nan
-    not. > @
-      eq.
-        nan
-        nan
-
-  # Tests that NaN is not less than a number.
-  [] +> tests-nan-not-lt-number
-    eq. > @
-      nan.lt 42
-      false
-
-  # Tests that NaN is not less than NaN.
-  [] +> tests-nan-not-lt-nan
-    eq. > @
-      nan.lt nan
-      false
-
-  # Tests that NaN is not less than or equal to a number.
-  [] +> tests-nan-not-lte-number
-    eq. > @
-      nan.lte 42
-      false
-
-  # Tests that NaN is not less than or equal to NaN.
-  [] +> tests-nan-not-lte-nan
-    eq. > @
-      nan.lte nan
-      false
-
-  # Tests that NaN is not greater than a number.
-  [] +> tests-nan-not-gt-number
-    eq. > @
-      nan.gt 42
-      false
-
-  # Tests that NaN is not greater than NaN.
-  [] +> tests-nan-not-gt-nan
-    eq. > @
-      nan.gt nan
-      false
-
-  # Tests that NaN is not greater than or equal to a number.
-  [] +> tests-nan-not-gte-number
-    eq. > @
-      nan.gte 42
-      false
-
-  # Tests that NaN is not greater than or equal to NaN.
-  [] +> tests-nan-not-gte-nan
-    eq. > @
-      nan.gte nan
-      false
-
-  # Tests that NaN multiplied by a number returns NaN.
-  [] +> tests-nan-times-number-is-nan
-    eq. > @
-      (nan.times 42).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN multiplied by NaN returns NaN.
-  [] +> tests-nan-times-nan-is-nan
-    eq. > @
-      (nan.times nan).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN divided by a number returns NaN.
-  [] +> tests-nan-div-number-is-nan
-    eq. > @
-      (nan.div 42).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN divided by NaN returns NaN.
-  [] +> tests-nan-div-nan-is-nan
-    eq. > @
-      (nan.div nan).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN plus a number returns NaN.
-  [] +> tests-nan-plus-number-is-nan
-    eq. > @
-      (nan.plus 42).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN plus NaN returns NaN.
-  [] +> tests-nan-plus-nan-is-nan
-    eq. > @
-      (nan.plus nan).as-bytes
-      nan.as-bytes
-
-  # Tests that negation of NaN returns NaN.
-  [] +> tests-nan-neg-is-nan
-    eq. > @
-      nan.@.as-bytes
-      nan.as-bytes
-
-  # Tests that NaN minus a number returns NaN.
-  [] +> tests-nan-minus-number-is-nan
-    eq. > @
-      (nan.minus 42).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN minus NaN returns NaN.
-  [] +> tests-nan-minus-nan-is-nan
-    eq. > @
-      (nan.minus nan).as-bytes
-      nan.as-bytes
-
-  # Tests that NaN as bytes equals the bytes of zero divided by zero.
-  [] +> tests-nan-as-bytes-is-bytes-of-zero-div-zero
-    eq. > @
-      nan.as-bytes
-      (0.0.div 0.0).as-bytes
-
-  # Tests that floor of NaN returns NaN.
-  [] +> tests-nan-floor-is-nan
-    eq. > @
-      nan.floor.as-bytes
-      nan.as-bytes
-
-  # Tests that NaN is detected as NaN.
-  nan.is-nan > [] +> nan-is-nan
-
-  # Tests that NaN is not a finite value.
-  nan.is-finite.not > [] +> nan-is-not-finite
-
-  # Tests that NaN is not an integer.
-  nan.is-integer.not > [] +> nan-is-not-integer
+  seq * ++> can-divide-by-zero
+    2.div 0
+    true
+
+  lt. ++> can-divide-into-less-than-one
+    1.div 5
+    1
+
+  eq. ++> can-divide-negative-infinity-by-a-negative-float
+    ninf.div -42.5
+    pinf
+
+  eq. ++> can-divide-negative-infinity-by-a-negative-integer
+    ninf.div -42
+    pinf
+
+  eq. ++> can-divide-negative-infinity-by-a-positive-float
+    ninf.div 42.5
+    ninf
+
+  eq. ++> can-divide-negative-infinity-by-a-positive-integer
+    ninf.div 42
+    ninf
+
+  eq. ++> can-divide-negative-infinity-by-float-zero
+    ninf.div 0
+    ninf
+
+  eq. ++> can-divide-negative-infinity-by-integer-zero
+    ninf.div 0
+    ninf
+
+  eq. ++> can-divide-negative-infinity-by-nan
+    as-bytes.
+      ninf.div nan
+    nan.as-bytes
+
+  eq. ++> can-divide-negative-infinity-by-negative-float-zero
+    ninf.div -0
+    pinf
+
+  eq. ++> can-divide-negative-infinity-by-negative-infinity
+    as-bytes.
+      ninf.div ninf
+    nan.as-bytes
+
+  eq. ++> can-divide-negative-infinity-by-negative-integer-zero
+    ninf.div -0
+    pinf
+
+  eq. ++> can-divide-negative-infinity-by-positive-infinity
+    as-bytes.
+      ninf.div pinf
+    nan.as-bytes
+
+  eq. ++> can-divide-positive-infinity-by-a-negative-float
+    pinf.div -42.5
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-a-negative-integer
+    pinf.div -42
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-a-positive-float
+    pinf.div 42.5
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-a-positive-integer
+    pinf.div 42
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-float-zero
+    pinf.div 0
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-integer-zero
+    pinf.div 0
+    pinf
+
+  eq. ++> can-divide-positive-infinity-by-nan
+    as-bytes.
+      pinf.div nan
+    nan.as-bytes
+
+  eq. ++> can-divide-positive-infinity-by-negative-float-zero
+    pinf.div -0
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-negative-infinity
+    as-bytes.
+      pinf.div ninf
+    nan.as-bytes
+
+  eq. ++> can-divide-positive-infinity-by-negative-integer-zero
+    pinf.div -0
+    ninf
+
+  eq. ++> can-divide-positive-infinity-by-positive-infinity
+    as-bytes.
+      pinf.div pinf
+    nan.as-bytes
+
+  eq. ++> can-divide-with-a-remainder
+    floor.
+      13.div -5
+    -3
+
+  ninf.eq ++> can-equal-minus-one-divided-by-zero-when-negative-infinity
+    -1.div 0
+
+  pinf.eq ++> can-equal-one-divided-by-zero-when-positive-infinity
+    1.div 0
+
+  nan.as-bytes.eq ++> can-expose-the-bytes-of-nan
+    as-bytes.
+      0.div 0
+
+  ninf.as-bytes.eq ++> can-expose-the-bytes-of-negative-infinity
+    as-bytes.
+      -1.div 0
+
+  pinf.as-bytes.eq ++> can-expose-the-bytes-of-positive-infinity
+    as-bytes.
+      1.div 0
+
+  eq. ++> can-multiply-by-zero
+    1000.times 0
+    0
+
+  eq. ++> can-multiply-negative-infinity-by-a-negative-float
+    ninf.times -42.5
+    pinf
+
+  eq. ++> can-multiply-negative-infinity-by-a-negative-integer
+    ninf.times -42
+    pinf
+
+  eq. ++> can-multiply-negative-infinity-by-a-positive-float
+    ninf.times 42.5
+    ninf
+
+  eq. ++> can-multiply-negative-infinity-by-a-positive-integer
+    ninf.times 42
+    ninf
+
+  eq. ++> can-multiply-negative-infinity-by-float-zero
+    as-bytes.
+      ninf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-negative-infinity-by-integer-zero
+    as-bytes.
+      ninf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-negative-infinity-by-nan
+    as-bytes.
+      ninf.times nan
+    nan.as-bytes
+
+  eq. ++> can-multiply-negative-infinity-by-negative-float-zero
+    as-bytes.
+      ninf.times -0
+    nan.as-bytes
+
+  eq. ++> can-multiply-negative-infinity-by-negative-infinity
+    ninf.times ninf
+    pinf
+
+  eq. ++> can-multiply-negative-infinity-by-positive-infinity
+    ninf.times pinf
+    ninf
+
+  eq. ++> can-multiply-positive-infinity-by-a-negative-float
+    pinf.times -42.5
+    ninf
+
+  eq. ++> can-multiply-positive-infinity-by-a-negative-integer
+    pinf.times -42
+    ninf
+
+  eq. ++> can-multiply-positive-infinity-by-a-positive-float
+    pinf.times 42.5
+    pinf
+
+  eq. ++> can-multiply-positive-infinity-by-a-positive-integer
+    pinf.times 42
+    pinf
+
+  eq. ++> can-multiply-positive-infinity-by-float-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-integer-zero
+    as-bytes.
+      pinf.times 0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-nan
+    as-bytes.
+      pinf.times nan
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-negative-float-zero
+    as-bytes.
+      pinf.times -0
+    nan.as-bytes
+
+  eq. ++> can-multiply-positive-infinity-by-negative-infinity
+    pinf.times ninf
+    ninf
+
+  eq. ++> can-multiply-positive-infinity-by-positive-infinity
+    pinf.times pinf
+    pinf
+
+  eq. ++> can-raise-to-a-power
+    2.power 4
+    16
+
+  eq. ++> can-raise-to-a-power-through-the-package
+    number.power
+      2
+      5
+    32
+
+  -17.9.abs.eq 17.9 ++> can-take-the-absolute-value-of-a-negative
+
+  eq. ++> can-take-the-modulo-of-two-numbers
+    7.mod 3
+    1
+
+  eq. ++> cannot-be-greater-than-a-float-when-negative-infinity
+    ninf.gt 42.5
+    false
+
+  eq. ++> cannot-be-greater-than-a-larger-integer
+    not.
+      0.gt 100
+    true
+
+  eq. ++> cannot-be-greater-than-a-number-when-nan
+    nan.gt 42
+    false
+
+  eq. ++> cannot-be-greater-than-an-equal-integer
+    not.
+      0.gt 0
+    true
+
+  eq. ++> cannot-be-greater-than-an-integer-when-negative-infinity
+    ninf.gt 42
+    false
+
+  not. ++> cannot-be-greater-than-itself-when-negative-infinity
+    ninf.gt ninf
+
+  not. ++> cannot-be-greater-than-itself-when-positive-infinity
+    pinf.gt pinf
+
+  eq. ++> cannot-be-greater-than-nan-when-nan
+    nan.gt nan
+    false
+
+  eq. ++> cannot-be-greater-than-nan-when-negative-infinity
+    ninf.gt nan
+    false
+
+  not. ++> cannot-be-greater-than-nan-when-positive-infinity
+    pinf.gt nan
+
+  eq. ++> cannot-be-greater-than-positive-infinity-when-negative-infinity
+    ninf.gt pinf
+    false

--- a/objects/number/abs.eo
+++ b/objects/number/abs.eo
@@ -1,0 +1,41 @@
+# Absolute value of `num` (i.e., with no sign).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > abs
+  if. > @
+    gte.
+      number num.as-bytes >> value
+      0
+    0.plus value
+    value.neg
+
+  eq. ++> can-normalize-the-sign-of-negative-zero
+    as-bytes.
+      abs -0
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-take-the-absolute-value-of-a-negative-float
+    abs -17.9
+    17.9
+
+  eq. ++> can-take-the-absolute-value-of-a-negative-integer
+    abs -3
+    3
+
+  eq. ++> can-take-the-absolute-value-of-a-positive-float
+    abs 13.5
+    13.5
+
+  eq. ++> can-take-the-absolute-value-of-a-positive-integer
+    abs 3
+    3
+
+  eq. ++> can-take-the-absolute-value-of-zero
+    abs 0
+    0

--- a/objects/number/arc-cosine.eo
+++ b/objects/number/arc-cosine.eo
@@ -1,0 +1,61 @@
+# Arc cosine of `num` as `org.eolang.number`, the angle in radians whose cosine
+# is `num`, taken as pi/2 minus the arc sine of the argument, since acos(x)
+# equals pi/2 minus asin(x). Arguments outside [-1, 1] and non-finite ones
+# collapse to nan.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > arc-cosine
+  minus. > @
+    pi.div 2
+    arc-sine num
+
+  eq. ++> can-take-an-arc-cosine-of-minus-one
+    arc-cosine -1
+    pi
+
+  lt. ++> can-take-an-arc-cosine-of-minus-zero-point-six
+    abs
+      minus.
+        times.
+          arc-cosine -0.6
+          1000
+        2214.297
+    1
+
+  eq. ++> can-take-an-arc-cosine-of-one
+    arc-cosine 1
+    0
+
+  eq. ++> can-take-an-arc-cosine-of-zero
+    arc-cosine 0
+    pi.div 2
+
+  lt. ++> can-take-an-arc-cosine-of-zero-point-six
+    abs
+      minus.
+        times.
+          arc-cosine 0.6
+          1000
+        927.295
+    1
+
+  is-nan. ++> cannot-take-an-arc-cosine-above-one
+    arc-cosine 2
+
+  is-nan. ++> cannot-take-an-arc-cosine-below-minus-one
+    arc-cosine -2
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-nan
+    arc-cosine nan
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-negative-infinity
+    arc-cosine ninf
+
+  is-nan. ++> cannot-take-an-arc-cosine-of-positive-infinity
+    arc-cosine pinf

--- a/objects/number/arc-sine.eo
+++ b/objects/number/arc-sine.eo
@@ -1,0 +1,131 @@
+# Arc sine of `num` as `org.eolang.number`, the angle in radians whose sine is
+# `num`. An argument above one half is folded toward zero through the identity
+# asin(x) equals pi/2 minus twice asin(sqrt((1 minus x) div 2)), so the Taylor
+# series always runs in its fast region, while arguments outside [-1, 1] and
+# non-finite ones collapse to nan.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > arc-sine
+  if. > @
+    lt.
+      number num.as-bytes >> arg
+      0
+    neg.
+      if. >> base
+        gt.
+          abs arg >> magnitude
+          0.5
+        minus.
+          pi.div 2
+          2.times
+            [point] >> series
+              point.times > @
+                poly 1
+              if. > [depth] > poly
+                depth.gt 30
+                1
+                1.plus
+                  times.
+                    div.
+                      times.
+                        times.
+                          minus. (depth.times 2) 1
+                          minus. (depth.times 2) 1
+                        squared
+                      times.
+                        depth.times 2
+                        plus. (depth.times 2) 1
+                    poly (depth.plus 1)
+              point.times point > squared
+            | (sqrt ((1.minus magnitude).div 2))
+        series magnitude
+    base
+
+  lt. ++> can-behave-as-an-odd-function
+    abs
+      times.
+        plus.
+          arc-sine 0.6
+          arc-sine -0.6
+        1000
+    1
+
+  lt. ++> can-take-an-arc-sine-of-a-half
+    abs
+      minus.
+        times.
+          arc-sine 0.5
+          1000
+        times.
+          pi.div 6
+          1000
+    1
+
+  lt. ++> can-take-an-arc-sine-of-minus-a-half
+    abs
+      minus.
+        times.
+          arc-sine -0.5
+          1000
+        times.
+          neg.
+            pi.div 6
+          1000
+    1
+
+  lt. ++> can-take-an-arc-sine-of-minus-one
+    abs
+      minus.
+        times.
+          arc-sine -1
+          1000
+        times.
+          neg.
+            pi.div 2
+          1000
+    1
+
+  lt. ++> can-take-an-arc-sine-of-one
+    abs
+      minus.
+        times.
+          arc-sine 1
+          1000
+        times.
+          pi.div 2
+          1000
+    1
+
+  eq. ++> can-take-an-arc-sine-of-zero
+    arc-sine 0
+    0
+
+  lt. ++> can-take-an-arc-sine-of-zero-point-six
+    abs
+      minus.
+        times.
+          arc-sine 0.6
+          1000
+        643.5
+    1
+
+  is-nan. ++> cannot-take-an-arc-sine-above-one
+    arc-sine 2
+
+  is-nan. ++> cannot-take-an-arc-sine-below-minus-one
+    arc-sine -2
+
+  is-nan. ++> cannot-take-an-arc-sine-of-nan
+    arc-sine nan
+
+  is-nan. ++> cannot-take-an-arc-sine-of-negative-infinity
+    arc-sine ninf
+
+  is-nan. ++> cannot-take-an-arc-sine-of-positive-infinity
+    arc-sine pinf

--- a/objects/number/as-i64.eo
+++ b/objects/number/as-i64.eo
@@ -1,0 +1,97 @@
+# Converts the number `n` to an `i64`, truncating the fractional part toward
+# zero. The exponent and the mantissa are pulled out of the IEEE 754 layout of
+# `n` and the magnitude is shifted into place, with the two's complement taken
+# when `n` is negative. When `n` does not fit into the bounds of an `i64`,
+# the caller-supplied `cant-convert` fallback is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n cant-convert] > as-i64
+  if. > @
+    or.
+      eq.
+        as-number. >> exp
+          as-i64.
+            right.
+              n.as-bytes.and 7F-F0-00-00-00-00-00-00
+              52
+        2047
+      or.
+        exp.gt 1086
+        and.
+          exp.eq 1086
+          not.
+            and.
+              eq. >> negative
+                n.as-bytes.and 80-00-00-00-00-00-00-00
+                80-00-00-00-00-00-00-00
+              eq.
+                or. >> mantissa
+                  n.as-bytes.and 00-0F-FF-FF-FF-FF-FF-FF
+                  00-10-00-00-00-00-00-00
+                00-10-00-00-00-00-00-00
+    cant-convert
+      "Can't convert number %f to i64 because it's out of i64 bounds".printf
+        * n
+    if.
+      exp.lt 1023
+      00-00-00-00-00-00-00-00.as-i64
+      if.
+        exp.eq 1086
+        80-00-00-00-00-00-00-00.as-i64
+        negative.if
+          magnitude.not.as-i64.plus 00-00-00-00-00-00-00-01.as-i64
+          as-i64.
+            if. >> magnitude
+              exp.gte 1075
+              mantissa.left
+                exp.minus 1075
+              mantissa.right
+                1075.minus exp
+
+  eq. ++> can-convert-a-fraction-below-one-to-zero
+    0.5.as-i64.as-bytes
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-convert-a-large-number-with-a-left-shift
+    1000000000000000000.as-i64.as-bytes
+    0D-E0-B6-B3-A7-64-00-00
+
+  eq. ++> can-convert-negative-zero-to-zero
+    -0.as-i64.as-bytes
+    00-00-00-00-00-00-00-00
+
+  eq. ++> can-convert-the-long-minimum-boundary
+    -9.223372036854776e18.as-i64.as-bytes
+    80-00-00-00-00-00-00-00
+
+  eq. ++> can-convert-the-origin-number
+    as-bytes.
+      as-i64 42
+    00-00-00-00-00-00-00-2A
+
+  eq. ++> can-truncate-a-negative-toward-zero
+    -3.7.as-i64.as-bytes
+    FF-FF-FF-FF-FF-FF-FF-FD
+
+  eq. ++> can-truncate-a-positive-toward-zero
+    3.7.as-i64.as-bytes
+    00-00-00-00-00-00-00-03
+
+  eq. ++> rejects-an-out-of-range-number
+    "recovered"
+    1.0e30.as-i64
+      "recovered" > [message]
+
+  1.0e30.as-i64 --> stops-on-converting-a-huge-number
+
+  nan.as-i64 --> stops-on-converting-nan
+
+  pinf.as-i64 --> stops-on-converting-positive-infinity
+
+  9.223372036854776e18.as-i64 --> stops-on-converting-the-long-maximum-boundary

--- a/objects/number/cosine.eo
+++ b/objects/number/cosine.eo
@@ -1,0 +1,90 @@
+# Cosine of `num` radians as `org.eolang.number`, taken from the sine of the
+# argument advanced by a quarter turn, since cos(x) equals sin(x + pi/2).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > cosine
+  sine > @
+    num.plus
+      pi.div 2
+
+  lt. ++> can-behave-as-an-even-function
+    abs
+      times.
+        minus.
+          cosine
+            pi.div 3
+          cosine (pi.div 3).neg
+        1000
+    1
+
+  lt. ++> can-reduce-a-large-angle
+    abs
+      minus.
+        times.
+          cosine
+            plus.
+              pi.times 10
+              pi.div 3
+          1000
+        500
+    1
+
+  lt. ++> can-take-a-cosine-of-pi
+    abs
+      minus.
+        times.
+          cosine pi
+          1000
+        -1000
+    1
+
+  lt. ++> can-take-a-cosine-of-pi-halves
+    abs
+      times.
+        cosine
+          pi.div 2
+        1000
+    1
+
+  lt. ++> can-take-a-cosine-of-pi-thirds
+    abs
+      minus.
+        times.
+          cosine
+            pi.div 3
+          1000
+        500
+    1
+
+  lt. ++> can-take-a-cosine-of-seventeen-radians
+    abs
+      minus.
+        times.
+          cosine 17
+          1000
+        -275
+    1
+
+  lt. ++> can-take-a-cosine-of-zero
+    abs
+      minus.
+        times.
+          cosine 0
+          1000
+        1000
+    1
+
+  is-nan. ++> cannot-take-a-cosine-of-nan
+    cosine nan
+
+  is-nan. ++> cannot-take-a-cosine-of-negative-infinity
+    cosine ninf
+
+  is-nan. ++> cannot-take-a-cosine-of-positive-infinity
+    cosine pinf

--- a/objects/number/degrees.eo
+++ b/objects/number/degrees.eo
@@ -1,0 +1,53 @@
+# Degrees of `num` radians as `org.eolang.number`, the same angle expressed in
+# degrees rather than radians, found by scaling the argument by 180 over pi.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > degrees
+  div. > @
+    times.
+      number num.as-bytes
+      180
+    pi
+
+  lt. ++> can-convert-minus-pi-to-degrees
+    abs
+      minus.
+        degrees pi.neg
+        -180
+    1.0E-4
+
+  lt. ++> can-convert-pi-halves-to-degrees
+    abs
+      minus.
+        degrees
+          pi.div 2
+        90
+    1.0E-4
+
+  lt. ++> can-convert-pi-to-degrees
+    abs
+      minus.
+        degrees pi
+        180
+    1.0E-4
+
+  lt. ++> can-convert-two-pi-to-degrees
+    abs
+      minus.
+        degrees
+          pi.times 2
+        360
+    1.0E-4
+
+  eq. ++> can-convert-zero-to-degrees
+    degrees 0
+    0
+
+  is-nan. ++> cannot-convert-nan-to-degrees
+    degrees nan

--- a/objects/number/eq.eo
+++ b/objects/number/eq.eo
@@ -1,0 +1,159 @@
+# TRUE when the number `n` equals `x`, FALSE otherwise. The comparison follows
+# IEEE 754: a not-a-number value is equal to nothing, not even to itself, while
+# positive and negative zero are equal to each other. Everything else is
+# compared byte by byte, so a value of any other type is simply not equal.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > eq
+  if. > @
+    n.is-nan.or
+      is-nan.
+        number
+          x >> xbts!
+    false
+    or.
+      and.
+        or.
+          xbts.eq
+            0.as-bytes >> pzero
+          xbts.eq
+            -0.as-bytes >> nzero
+        or.
+          eq.
+            n.as-bytes >> b!
+            pzero
+          b.eq nzero
+      b.eq xbts
+
+  eq. ++> can-compare-two-different-number-types
+    68.eq "12345678"
+    false
+
+  eq. ++> can-compare-two-numbers-through-the-package
+    eq
+      42
+      42
+    true
+
+  42.eq 42.as-bytes ++> can-equal-an-integer-through-bytes
+
+  eq. ++> can-equal-float-zero-to-integer-zero
+    0.eq 0
+    true
+
+  ninf.eq ninf ++> can-equal-negative-infinity-when-negative-infinity
+
+  pinf.eq pinf ++> can-equal-positive-infinity-when-positive-infinity
+
+  eq. ++> can-equal-the-same-integer
+    123.eq 123
+    true
+
+  eq. ++> can-equal-zero-to-zero
+    0.eq 0
+    true
+
+  eq. ++> cannot-equal-a-different-integer
+    not.
+      123.eq 42
+    true
+
+  not. ++> cannot-equal-a-float-when-negative-infinity
+    ninf.eq 42.5
+
+  not. ++> cannot-equal-a-float-when-positive-infinity
+    pinf.eq 42.5
+
+  not. ++> cannot-equal-a-number-when-nan
+    nan.eq 42
+
+  not. ++> cannot-equal-an-integer-when-negative-infinity
+    ninf.eq 42
+
+  not. ++> cannot-equal-an-integer-when-positive-infinity
+    pinf.eq 42
+
+  eq. ++> cannot-equal-nan-or-infinities-when-a-float-under-load
+    and.
+      and.
+        and.
+          and.
+            and.
+              and.
+                and.
+                  and.
+                    and.
+                      and.
+                        and.
+                          eq. (0.eq nan) false
+                          eq. (0.eq pinf) false
+                        eq. (0.eq ninf) false
+                      eq. (42.5.eq nan) false
+                    eq. (42.5.eq pinf) false
+                  eq. (42.5.eq ninf) false
+                eq.
+                  0.eq nan
+                  false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.5.eq nan
+            false
+        eq.
+          42.5.eq pinf
+          false
+      eq.
+        42.5.eq ninf
+        false
+    true
+
+  eq. ++> cannot-equal-nan-or-infinities-when-an-integer
+    and.
+      and.
+        and.
+          and.
+            and.
+              eq.
+                0.eq nan
+                false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.eq nan
+            false
+        eq.
+          42.eq pinf
+          false
+      eq.
+        42.eq ninf
+        false
+    true
+
+  not. ++> cannot-equal-nan-when-nan
+    nan.eq nan
+
+  not. ++> cannot-equal-nan-when-negative-infinity
+    ninf.eq nan
+
+  not. ++> cannot-equal-nan-when-positive-infinity
+    pinf.eq nan
+
+  not. ++> cannot-equal-negative-infinity-when-positive-infinity
+    pinf.eq ninf
+
+  not. ++> cannot-equal-positive-infinity-when-negative-infinity
+    ninf.eq pinf

--- a/objects/number/exp.eo
+++ b/objects/number/exp.eo
@@ -1,0 +1,51 @@
+# Returns Euler's number raised to the power of a `num`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > exp
+  power > @
+    e
+    num
+
+  lt. ++> can-exponentiate-five
+    abs
+      minus.
+        power e 5
+        exp 5
+    1.0E-7
+
+  lt. ++> can-exponentiate-minus-one
+    abs
+      minus.
+        1.div e
+        exp -1
+    1.0E-8
+
+  lt. ++> can-exponentiate-minus-ten
+    abs
+      minus.
+        power e -10
+        exp -10
+    1.0E-12
+
+  eq. ++> can-exponentiate-negative-infinity
+    exp ninf
+    0
+
+  lt. ++> can-exponentiate-one
+    abs
+      e.minus
+        exp 1
+    1.0E-8
+
+  eq. ++> can-exponentiate-positive-infinity
+    exp pinf
+    pinf
+
+  is-nan. ++> cannot-exponentiate-nan
+    exp nan

--- a/objects/number/floor.eo
+++ b/objects/number/floor.eo
@@ -1,0 +1,43 @@
+# Largest integer not greater than `n`. Non-finite numbers and magnitudes
+# beyond the range of exact integers are returned unchanged.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > floor
+  if. > @
+    n.is-finite.not.or
+      or.
+        n.gte 4503599627370496
+        n.lte -4503599627370496
+    n
+    if.
+      gt.
+        n.as-i64.as-number >> trunc
+        n
+      trunc.minus 1
+      n.as-i64.as-number
+
+  -1.0e20.floor.eq -1.0e20 ++> can-floor-a-large-negative-integer
+
+  1.0e20.floor.eq 1.0e20 ++> can-floor-a-large-positive-integer
+
+  -3.7.floor.eq -4 ++> can-floor-a-negative-fraction
+
+  -5.floor.eq -5 ++> can-floor-a-negative-integer
+
+  3.7.floor.eq 3 ++> can-floor-a-positive-fraction
+
+  -0.1.floor.eq -1 ++> can-floor-a-small-negative-fraction
+
+  42.floor.eq 42 ++> can-floor-an-integer
+
+  ninf.floor.eq ninf ++> can-floor-negative-infinity
+
+  pinf.floor.eq pinf ++> can-floor-positive-infinity
+
+  0.floor.eq 0 ++> can-floor-zero

--- a/objects/number/gte.eo
+++ b/objects/number/gte.eo
@@ -1,0 +1,75 @@
+# TRUE when `n` is greater than or equal to `x`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > gte
+  or. > @
+    n.gt
+      x >> value!
+    n.eq value
+
+  eq. ++> can-be-greater-than-or-equal-to-a-float-when-positive-infinity
+    pinf.gte 42.5
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-a-smaller-integer
+    -1000.gte -1100
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-an-equal-integer
+    113.gte 113
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-an-integer-when-positive-infinity
+    pinf.gte 42
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-negative-infinity-when-negative-infinity
+    ninf.gte ninf
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-negative-infinity-when-positive-infinity
+    pinf.gte ninf
+    true
+
+  eq. ++> can-be-greater-than-or-equal-to-positive-infinity-when-positive-infinity
+    pinf.gte pinf
+    true
+
+  eq. ++> cannot-be-greater-than-or-equal-to-a-float-when-negative-infinity
+    ninf.gte 42.5
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-a-larger-integer
+    not.
+      0.gte 10
+    true
+
+  eq. ++> cannot-be-greater-than-or-equal-to-a-number-when-nan
+    nan.gte 42
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-an-integer-when-negative-infinity
+    ninf.gte 42
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-nan
+    nan.gte nan
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-negative-infinity
+    ninf.gte nan
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-nan-when-positive-infinity
+    pinf.gte nan
+    false
+
+  eq. ++> cannot-be-greater-than-or-equal-to-positive-infinity-when-negative-infinity
+    ninf.gte pinf
+    false

--- a/objects/number/integral.eo
+++ b/objects/number/integral.eo
@@ -1,0 +1,200 @@
+# Calculates the integral from `a` to `b`.
+# Here `func` is the integration function, `a` is the lower limit,
+# `b` is the upper limit, `n` is the number of partitions of the integration interval.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[fun a b n] > integral
+  if. > @
+    n.is-finite.and
+      n.is-integer.and
+        n.gt 0
+    as-number.
+      malloc.of
+        8
+        [sum] >>
+          seq * > @
+            while
+              if. > [i] >>
+                i.lt n
+                seq *
+                  sum.put
+                    sum.as-number.plus
+                      subsection
+                        a.plus (i.times step)
+                        a.plus ((i.plus 1).times step)
+                  true
+                false
+              true > [i]
+            sum
+          as-number. > step
+            div.
+              b.minus a
+              n
+    T
+      "the number of partitions must be a finite positive integer"
+  times. > [a b] >> subsection
+    div.
+      b.minus a
+      6
+    plus.
+      fun a
+      plus.
+        4.times
+          fun
+            0.5.times
+              a.plus b
+        fun b
+
+  ++> can-integrate-a-cubic-function
+    close-to > @
+      as-number.
+        integral
+          times. > [x]
+            x.times x
+            x
+          1
+          10
+          100
+      2499.75
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> can-integrate-a-linear-function
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          1
+          10
+          15
+      49.5
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> can-integrate-a-quadratic-function
+    close-to > @
+      as-number.
+        integral
+          x.times x > [x]
+          1
+          10
+          100
+      333
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> can-integrate-with-a-single-partition
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          0
+          1
+          1
+      0.5
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  ++> can-integrate-with-an-evenly-dividing-step
+    close-to > @
+      as-number.
+        integral
+          x > [x]
+          0
+          10
+          10
+      50
+      1.0E-7
+    [value operand err] > close-to
+      lte. > @
+        minus.
+          abs
+            value.minus operand
+          err
+        0
+      if. > [value] > abs
+        value.gte 0
+        value
+        value.neg
+
+  integral --> stops-on-fractional-partitions
+    x > [x]
+    0
+    1
+    1.5
+
+  integral --> stops-on-nan-partitions
+    x > [x]
+    0
+    1
+    nan
+
+  integral --> stops-on-negative-partitions
+    x > [x]
+    0
+    1
+    -1
+
+  integral --> stops-on-negatively-infinite-partitions
+    x > [x]
+    0
+    1
+    ninf
+
+  integral --> stops-on-positively-infinite-partitions
+    x > [x]
+    0
+    1
+    pinf
+
+  integral --> stops-on-zero-partitions
+    x > [x]
+    0
+    1
+    0

--- a/objects/number/is-finite.eo
+++ b/objects/number/is-finite.eo
@@ -1,0 +1,27 @@
+# TRUE when `n` is neither infinite nor not-a-number.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > is-finite
+  n.is-nan.not.and > @
+    not.
+      or.
+        n.as-bytes.eq 7F-F0-00-00-00-00-00-00
+        n.as-bytes.eq FF-F0-00-00-00-00-00-00
+
+  32.is-finite ++> can-be-finite-when-a-simple-number
+
+  not. ++> cannot-be-finite-when-built-of-infinite-bytes
+    is-finite.
+      number pinf.as-bytes
+
+  nan.is-finite.not ++> cannot-be-finite-when-nan
+
+  ninf.is-finite.not ++> cannot-be-finite-when-negative-infinity
+
+  pinf.is-finite.not ++> cannot-be-finite-when-positive-infinity

--- a/objects/number/is-integer.eo
+++ b/objects/number/is-integer.eo
@@ -1,0 +1,22 @@
+# TRUE when `n` is finite and equal to its own floor.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > is-integer
+  n.is-finite.and > @
+    n.eq n.floor
+
+  32.is-integer ++> can-be-an-integer-when-a-whole-number
+
+  32.5.is-integer.not ++> cannot-be-an-integer-when-a-float
+
+  nan.is-integer.not ++> cannot-be-an-integer-when-nan
+
+  ninf.is-integer.not ++> cannot-be-an-integer-when-negative-infinity
+
+  pinf.is-integer.not ++> cannot-be-an-integer-when-positive-infinity

--- a/objects/number/is-nan.eo
+++ b/objects/number/is-nan.eo
@@ -1,0 +1,83 @@
+# TRUE when `n` is the not-a-number value, FALSE otherwise.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > is-nan
+  if. > @
+    and.
+      bts.size.gt 7
+      not.
+        bts.size.gt 8
+    and.
+      eq.
+        bts.and 7F-F0-00-00-00-00-00-00
+        7F-F0-00-00-00-00-00-00
+      not.
+        eq.
+          bts.and 00-0F-FF-FF-FF-FF-FF-FF
+          00-00-00-00-00-00-00-00
+    false
+  n.as-bytes > bts
+
+  is-nan. ++> can-be-nan-when-built-of-nan-bytes
+    number nan.as-bytes
+
+  is-nan. ++> can-be-nan-when-built-of-non-canonical-nan-bytes
+    number FF-F8-00-00-00-00-00-00
+
+  nan.is-nan ++> can-be-nan-when-nan
+
+  eq. ++> can-be-nan-when-nan-divided-by-a-number
+    as-bytes.
+      nan.div 42
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-divided-by-nan
+    as-bytes.
+      nan.div nan
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-minus-a-number
+    as-bytes.
+      nan.minus 42
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-minus-nan
+    as-bytes.
+      nan.minus nan
+    nan.as-bytes
+
+  nan.@.as-bytes.eq nan.as-bytes ++> can-be-nan-when-nan-negated
+
+  eq. ++> can-be-nan-when-nan-plus-a-number
+    as-bytes.
+      nan.plus 42
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-plus-nan
+    as-bytes.
+      nan.plus nan
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-times-a-number
+    as-bytes.
+      nan.times 42
+    nan.as-bytes
+
+  eq. ++> can-be-nan-when-nan-times-nan
+    as-bytes.
+      nan.times nan
+    nan.as-bytes
+
+  nan.floor.as-bytes.eq nan.as-bytes ++> can-be-nan-when-the-floor-of-nan
+
+  42.5.is-nan.not ++> cannot-be-nan-when-a-simple-number
+
+  ninf.is-nan.not ++> cannot-be-nan-when-negative-infinity
+
+  pinf.is-nan.not ++> cannot-be-nan-when-positive-infinity

--- a/objects/number/ln.eo
+++ b/objects/number/ln.eo
@@ -1,0 +1,106 @@
+# Natural logarithm of `num` with base `e` as `org.eolang.number`. The argument
+# is folded into [1/e, e] by peeling whole factors of `e` and counting them,
+# then the remainder is summed with the area-hyperbolic-tangent series. The
+# limiting cases follow the usual conventions: zero is negative infinity, a
+# negative number and negative infinity are nan, and positive infinity stays.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > ln
+  n.is-nan.if > @
+    nan
+    if.
+      n.lt 0
+      nan
+      if.
+        n.eq 0
+        ninf
+        n.is-finite.if
+          lnp n
+          pinf
+  [p] > lnp
+    if. > @
+      p.gte e
+      plus.
+        lnp
+          p.div e
+        1
+      if.
+        p.lt
+          1.div e
+        minus.
+          lnp
+            p.times e
+          1
+        series p
+    [m] > series
+      2.times > @
+        t.times
+          horner 0
+      if. > [k] > horner
+        k.gt 40
+        0
+        plus.
+          1.div
+            plus.
+              k.times 2
+              1
+          times.
+            t.times t
+            horner
+              k.plus 1
+      div. > t
+        m.minus 1
+        m.plus 1
+  number num.as-bytes > n
+
+  lt. ++> can-stay-monotonic
+    ln 2
+    ln 3
+
+  lt. ++> can-take-a-logarithm-of-a-fraction
+    abs
+      minus.
+        ln 0.5
+        -0.6931471805599453
+    1.0E-11
+
+  eq. ++> can-take-a-logarithm-of-e
+    ln e
+    1
+
+  eq. ++> can-take-a-logarithm-of-one
+    ln 1
+    0
+
+  eq. ++> can-take-a-logarithm-of-positive-infinity
+    ln pinf
+    pinf
+
+  lt. ++> can-take-a-logarithm-of-twenty
+    abs
+      minus.
+        ln 20
+        2.995732273553991
+    1.0E-11
+
+  eq. ++> can-take-a-logarithm-of-zero
+    ln 0
+    ninf
+
+  is-nan. ++> cannot-take-a-logarithm-of-a-negative-float
+    ln -2.2
+
+  is-nan. ++> cannot-take-a-logarithm-of-a-negative-integer
+    ln -42
+
+  is-nan. ++> cannot-take-a-logarithm-of-nan
+    ln nan
+
+  is-nan. ++> cannot-take-a-logarithm-of-negative-infinity
+    ln ninf

--- a/objects/number/lt.eo
+++ b/objects/number/lt.eo
@@ -1,0 +1,69 @@
+# TRUE when `n` is strictly less than `x`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > lt
+  0.gt > @
+    n.minus
+      number x!
+
+  ninf.lt 42.5 ++> can-be-less-than-a-float-when-negative-infinity
+
+  10.lt 50 ++> can-be-less-than-a-larger-integer
+
+  ninf.lt 42 ++> can-be-less-than-an-integer-when-negative-infinity
+
+  eq. ++> can-be-less-than-positive-infinity-when-negative-infinity
+    ninf.lt pinf
+    true
+
+  eq. ++> cannot-be-less-than-a-float-when-positive-infinity
+    pinf.lt 42.5
+    false
+
+  eq. ++> cannot-be-less-than-a-number-when-nan
+    nan.lt 42
+    false
+
+  eq. ++> cannot-be-less-than-a-smaller-integer
+    not.
+      10.lt -5
+    true
+
+  eq. ++> cannot-be-less-than-an-equal-integer
+    not.
+      10.lt 10
+    true
+
+  eq. ++> cannot-be-less-than-an-integer-when-positive-infinity
+    pinf.lt 42
+    false
+
+  eq. ++> cannot-be-less-than-itself-when-negative-infinity
+    ninf.lt ninf
+    false
+
+  eq. ++> cannot-be-less-than-itself-when-positive-infinity
+    pinf.lt pinf
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-nan
+    nan.lt nan
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-negative-infinity
+    ninf.lt nan
+    false
+
+  eq. ++> cannot-be-less-than-nan-when-positive-infinity
+    pinf.lt nan
+    false
+
+  eq. ++> cannot-be-less-than-negative-infinity-when-positive-infinity
+    pinf.lt ninf
+    false

--- a/objects/number/lte.eo
+++ b/objects/number/lte.eo
@@ -1,0 +1,75 @@
+# TRUE when `n` is less than or equal to `x`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > lte
+  or. > @
+    n.lt
+      x >> value!
+    n.eq value
+
+  eq. ++> can-be-less-than-or-equal-to-a-float-when-negative-infinity
+    ninf.lte 42.5
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-a-larger-integer
+    -200.lte -100
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-an-equal-integer
+    50.lte 50
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-an-integer-when-negative-infinity
+    ninf.lte 42
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-negative-infinity-when-negative-infinity
+    ninf.lte ninf
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-positive-infinity-when-negative-infinity
+    ninf.lte pinf
+    true
+
+  eq. ++> can-be-less-than-or-equal-to-positive-infinity-when-positive-infinity
+    pinf.lte pinf
+    true
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-float-when-positive-infinity
+    pinf.lte 42.5
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-number-when-nan
+    nan.lte 42
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-a-smaller-integer
+    not.
+      0.lte -10
+    true
+
+  eq. ++> cannot-be-less-than-or-equal-to-an-integer-when-positive-infinity
+    pinf.lte 42
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-nan
+    nan.lte nan
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-negative-infinity
+    ninf.lte nan
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-nan-when-positive-infinity
+    pinf.lte nan
+    false
+
+  eq. ++> cannot-be-less-than-or-equal-to-negative-infinity-when-positive-infinity
+    pinf.lte ninf
+    false

--- a/objects/number/minus.eo
+++ b/objects/number/minus.eo
@@ -1,0 +1,77 @@
+# Difference of `n` and `x`, defined as `n` plus the negation of `x`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x] > minus
+  n.plus > @
+    neg.
+      number x!
+
+  eq. ++> can-subtract-a-negative-float-from-negative-infinity
+    ninf.minus -42.5
+    ninf
+
+  eq. ++> can-subtract-a-negative-float-from-positive-infinity
+    pinf.minus -42.5
+    pinf
+
+  eq. ++> can-subtract-a-negative-integer-from-negative-infinity
+    ninf.minus -42
+    ninf
+
+  eq. ++> can-subtract-a-negative-integer-from-positive-infinity
+    pinf.minus -42
+    pinf
+
+  eq. ++> can-subtract-a-positive-float-from-negative-infinity
+    ninf.minus 42.5
+    ninf
+
+  eq. ++> can-subtract-a-positive-float-from-positive-infinity
+    pinf.minus 42.5
+    pinf
+
+  eq. ++> can-subtract-a-positive-integer-from-negative-infinity
+    ninf.minus 42
+    ninf
+
+  eq. ++> can-subtract-a-positive-integer-from-positive-infinity
+    pinf.minus 42
+    pinf
+
+  eq. ++> can-subtract-nan-from-negative-infinity
+    as-bytes.
+      ninf.minus nan
+    nan.as-bytes
+
+  eq. ++> can-subtract-nan-from-positive-infinity
+    as-bytes.
+      pinf.minus nan
+    nan.as-bytes
+
+  eq. ++> can-subtract-negative-infinity-from-negative-infinity
+    as-bytes.
+      ninf.minus ninf
+    nan.as-bytes
+
+  eq. ++> can-subtract-negative-infinity-from-positive-infinity
+    pinf.minus ninf
+    pinf
+
+  eq. ++> can-subtract-one-from-one
+    1.minus 1
+    0
+
+  eq. ++> can-subtract-positive-infinity-from-negative-infinity
+    ninf.minus pinf
+    ninf
+
+  eq. ++> can-subtract-positive-infinity-from-positive-infinity
+    as-bytes.
+      pinf.minus pinf
+    nan.as-bytes

--- a/objects/number/mod.eo
+++ b/objects/number/mod.eo
@@ -1,0 +1,113 @@
+# Calculate MOD.
+# An operation that finds the remainder after dividing `x` by `y`. When `y`
+# is zero, the result is the caller-supplied `cant-mod` fallback, or the
+# bottom object when none was provided, which terminates on use.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[x y cant-mod] > mod
+  if. > @
+    eq.
+      number y.as-bytes >> divisor
+      0
+    cant-mod
+      "cannot calculate mod by zero"
+    divisor.is-finite.not.if
+      x
+      if.
+        gt.
+          number x.as-bytes >> dividend
+          0
+        [] >> abs-mod
+          minus. > @
+            abs dividend >> absx
+            times.
+              abs divisor >> absy
+              floor.
+                absx.div absy
+        abs-mod.neg
+
+  ++> can-stay-compatible-with-division
+    eq. > @
+      plus.
+        mod dividend divisor
+        divisor.times (dividend.div divisor).as-i64.as-number
+      dividend
+    -13 > dividend
+    5 > divisor
+
+  eq. ++> can-take-a-modulo-by-one
+    mod
+      133
+      1
+    0
+
+  eq. ++> can-take-a-modulo-of-a-dividend-below-the-divisor
+    mod
+      -1
+      5
+    -1
+
+  eq. ++> can-take-a-modulo-of-a-negative-by-positive-infinity
+    mod
+      -5
+      pinf
+    -5
+
+  eq. ++> can-take-a-modulo-of-a-positive-by-negative-infinity
+    mod
+      5
+      ninf
+    5
+
+  eq. ++> can-take-a-modulo-of-a-positive-by-positive-infinity
+    mod
+      5
+      pinf
+    5
+
+  eq. ++> can-take-a-modulo-of-minus-one-by-seven
+    mod
+      -1
+      7
+    -1
+
+  eq. ++> can-take-a-modulo-of-one-by-two
+    mod
+      1
+      2
+    1
+
+  eq. ++> can-take-a-modulo-of-sixteen-by-a-large-negative
+    mod
+      16
+      -200
+    16
+
+  eq. ++> can-take-a-modulo-of-zero-by-a-negative
+    mod
+      0
+      -15
+    0
+
+  eq. ++> can-take-a-modulo-of-zero-by-five
+    mod
+      0
+      5
+    0
+
+  eq. ++> rejects-a-modulo-by-zero
+    "recovered"
+    mod
+      5
+      0
+      "recovered" > [message]
+
+  mod --> stops-on-a-modulo-by-zero
+    5
+    0

--- a/objects/number/neg.eo
+++ b/objects/number/neg.eo
@@ -1,0 +1,15 @@
+# Negation of `n`: the same magnitude with the opposite sign.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > neg
+  n.times -1 > @
+
+  ninf.neg.eq pinf ++> can-negate-negative-infinity
+
+  pinf.neg.eq ninf ++> can-negate-positive-infinity

--- a/objects/number/power.eo
+++ b/objects/number/power.eo
@@ -1,0 +1,391 @@
+# Raises `num` to the power of `x` as `org.eolang.number`. A zero exponent gives
+# one, an integer exponent is expanded by exponentiation-by-squaring so integer
+# results stay exact, and a fractional exponent of a positive base is taken as
+# e raised to `x` times the natural logarithm of the base. Zeros, infinities and
+# nan follow the same IEEE rules that Math.pow obeys.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num x] > power
+  if. > @
+    eq.
+      number x.as-bytes >> expo
+      0
+    1
+    base.is-nan.if
+      nan
+      expo.is-nan.if
+        nan
+        expo.is-finite.if
+          base.is-finite.if
+            if.
+              eq.
+                number num.as-bytes >> base
+                0
+              if.
+                expo.gt 0
+                0
+                pinf
+              expo.is-integer.if
+                if.
+                  expo.lt 0
+                  1.div
+                    [b n] >> ipow
+                      if. > @
+                        n.eq 0
+                        1
+                        if.
+                          is-integer. (n.div 2)
+                          half.times half
+                          b.times
+                            ipow b (n.minus 1)
+                      ipow b (n.div 2) > half
+                    | base (abs expo)
+                  ipow base (abs expo)
+                if.
+                  base.gt 0
+                  [y] >> expon
+                    times. > @
+                      if.
+                        k.lt 0
+                        1.div
+                          ipow e (abs k)
+                        ipow e (abs k)
+                      fraction 1
+                    if. > [j] > fraction
+                      j.gt 20
+                      1
+                      1.plus
+                        times.
+                          div. (y.minus k) j
+                          fraction (j.plus 1)
+                    floor. (y.plus 0.5) > k
+                  | (expo.times (ln base))
+                  nan
+            if.
+              base.gt 0
+              if.
+                expo.gt 0
+                pinf
+                0
+              if.
+                expo.gt 0
+                if.
+                  expo.is-integer.and (expo.div 2).is-integer.not >> odd
+                  ninf
+                  pinf
+                odd.if 0.neg 0
+          if.
+            expo.gt 0
+            if.
+              gt.
+                abs base
+                1
+              pinf
+              if.
+                eq.
+                  abs base
+                  1
+                nan
+                0
+            if.
+              gt.
+                abs base
+                1
+              0
+              if.
+                eq.
+                  abs base
+                  1
+                nan
+                pinf
+
+  eq. ++> can-be-called-as-a-method-on-a-number
+    2.power 4
+    16
+
+  eq. ++> can-be-called-as-a-method-with-a-bound-receiver
+    3.power 2
+    9
+
+  eq. ++> can-be-reached-through-the-package
+    power
+      2
+      4
+    16
+
+  eq. ++> can-raise-a-float-to-zero
+    power
+      42.5
+      0
+    1
+
+  eq. ++> can-raise-a-negative-float-to-negative-infinity
+    power
+      -42.5
+      ninf
+    0
+
+  eq. ++> can-raise-a-negative-float-to-positive-infinity
+    power
+      -4.2
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-negative-integer-to-negative-infinity
+    power
+      -42
+      ninf
+    0
+
+  eq. ++> can-raise-a-negative-integer-to-positive-infinity
+    power
+      -10
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-positive-float-to-a-positive-integer
+    power
+      3.5
+      4
+    150.0625
+
+  eq. ++> can-raise-a-positive-float-to-negative-infinity
+    power
+      42.5
+      ninf
+    0
+
+  eq. ++> can-raise-a-positive-float-to-positive-infinity
+    power
+      42.5
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-positive-integer-to-a-positive-integer
+    power
+      2
+      3
+    8
+
+  eq. ++> can-raise-a-positive-integer-to-negative-infinity
+    power
+      42
+      ninf
+    0
+
+  eq. ++> can-raise-a-positive-integer-to-positive-infinity
+    power
+      42
+      pinf
+    pinf
+
+  eq. ++> can-raise-a-zero-base
+    power
+      0
+      145
+    0
+
+  eq. ++> can-raise-an-integer-to-zero
+    power
+      42
+      0
+    1
+
+  eq. ++> can-raise-four-to-five
+    power
+      4
+      5
+    1024
+
+  eq. ++> can-raise-four-to-minus-three
+    power
+      4
+      -3
+    0.015625
+
+  eq. ++> can-raise-negative-infinity-to-a-positive-float
+    power
+      ninf
+      9.9
+    pinf
+
+  eq. ++> can-raise-negative-infinity-to-an-even-integer
+    power
+      ninf
+      10
+    pinf
+
+  eq. ++> can-raise-negative-infinity-to-an-odd-integer
+    power
+      ninf
+      9
+    ninf
+
+  eq. ++> can-raise-negative-infinity-to-negative-infinity
+    power
+      ninf
+      ninf
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-negative-float
+    power
+      pinf
+      -42.2
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-negative-integer
+    power
+      pinf
+      -42
+    0
+
+  eq. ++> can-raise-positive-infinity-to-a-positive-float
+    power
+      pinf
+      10.8
+    pinf
+
+  eq. ++> can-raise-positive-infinity-to-a-positive-integer
+    power
+      pinf
+      42
+    pinf
+
+  eq. ++> can-raise-positive-infinity-to-negative-infinity
+    power
+      pinf
+      ninf
+    0
+
+  eq. ++> can-raise-positive-infinity-to-positive-infinity
+    power
+      pinf
+      pinf
+    pinf
+
+  eq. ++> can-raise-three-to-two
+    power
+      3
+      2
+    9
+
+  eq. ++> can-raise-to-a-large-negative-exponent
+    power
+      984782
+      -12341
+    0
+
+  eq. ++> can-raise-to-a-zero-exponent
+    power
+      2
+      0
+    1
+
+  eq. ++> can-raise-two-to-four
+    power
+      2
+      4
+    16
+
+  eq. ++> can-raise-two-to-minus-one
+    power
+      2
+      -1
+    0.5
+
+  eq. ++> can-raise-two-to-minus-three
+    power
+      2
+      -3
+    0.125
+
+  eq. ++> can-raise-two-to-minus-two
+    power
+      2
+      -2
+    0.25
+
+  eq. ++> can-raise-zero-to-a-negative
+    power
+      0
+      -52
+    pinf
+
+  eq. ++> can-raise-zero-to-a-negative-odd-integer
+    power
+      0
+      -567
+    pinf
+
+  eq. ++> can-raise-zero-to-a-positive-float
+    power
+      0
+      4.2
+    0
+
+  eq. ++> can-raise-zero-to-a-positive-integer
+    power
+      0
+      4
+    0
+
+  eq. ++> can-raise-zero-to-negative-infinity
+    power
+      0
+      ninf
+    pinf
+
+  eq. ++> can-raise-zero-to-positive-infinity
+    power
+      0
+      pinf
+    0
+
+  lt. ++> can-take-a-cube-root-of-twenty-seven
+    abs
+      minus.
+        power
+          27
+          1.div 3
+        3
+    1.0E-9
+
+  lt. ++> can-take-a-square-root-of-nine
+    abs
+      minus.
+        power 9 0.5
+        3
+    1.0E-9
+
+  lt. ++> can-take-a-square-root-of-two
+    abs
+      minus.
+        power 2 0.5
+        1.4142135623730951
+    1.0E-9
+
+  is-nan. ++> cannot-raise-a-negative-to-a-fraction
+    power
+      -4
+      0.5
+
+  is-nan. ++> cannot-raise-anything-to-nan
+    power
+      52
+      nan
+
+  is-nan. ++> cannot-raise-nan-to-anything
+    power
+      nan
+      42
+
+  is-nan. ++> cannot-raise-nan-to-nan
+    power
+      nan
+      nan

--- a/objects/number/radians.eo
+++ b/objects/number/radians.eo
@@ -1,0 +1,51 @@
+# Radians of `num` degrees as `org.eolang.number`, the same angle expressed in
+# radians rather than degrees, found by scaling the argument by pi over 180.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > radians
+  div. > @
+    times.
+      number num.as-bytes
+      pi
+    180
+
+  lt. ++> can-convert-a-full-turn-to-radians
+    abs
+      minus.
+        radians 360
+        pi.times 2
+    1.0E-4
+
+  lt. ++> can-convert-a-half-turn-to-radians
+    abs
+      minus.
+        radians 180
+        pi
+    1.0E-4
+
+  lt. ++> can-convert-a-negative-half-turn-to-radians
+    abs
+      minus.
+        radians -180
+        pi.neg
+    1.0E-4
+
+  lt. ++> can-convert-a-quarter-turn-to-radians
+    abs
+      minus.
+        radians 90
+        pi.div 2
+    1.0E-4
+
+  eq. ++> can-convert-zero-to-radians
+    radians 0
+    0
+
+  is-nan. ++> cannot-convert-nan-to-radians
+    radians nan

--- a/objects/number/random.eo
+++ b/objects/number/random.eo
@@ -1,0 +1,92 @@
+# Generates a pseudo-random number.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
+
+[seed] > random
+  seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
+  [clock] > clocked
+    random > @
+      as-number.
+        plus.
+          as-i64.
+            and.
+              tbytes.left shift1
+              as-bytes.
+                minus. (one.left 53).as-i64 one
+          plus.
+            as-i64.
+              and.
+                tbytes.left shift3
+                as-bytes.
+                  minus. (one.left shift1).as-i64 one
+            as-i64.
+              tbytes.and ((one.left shift3).as-i64.minus one).as-bytes
+    00-00-00-00-00-00-00-01 > one
+    35 > shift1
+    17 > shift3
+    clock.as-bytes > tbytes
+  random > next
+    as-number.
+      as-i64.
+        and.
+          as-bytes.
+            plus.
+              plus.
+                as-i64.
+                  left.
+                    and.
+                      as-bytes.
+                        ((seed.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                          25214903917.as-i64
+                      00-00-00-00-03-FF-FF-FF
+                    26
+                as-i64.
+                  (seed.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
+                    25214903917.as-i64
+              11.as-i64
+          00-1F-FF-FF-FF-FF-FF-FF
+  clocked clock > pseudo
+
+  not. ++> can-differ-between-two-draws
+    eq.
+      random.clocked 123.as-i64
+      random.clocked 456.as-i64
+
+  ++> can-reach-the-upper-half
+    not. > @
+      rand.lt 0.5
+    next. > rand
+      random 178609
+
+  eq. ++> can-repeat-itself-with-the-same-seed
+    next. (random 1654).next.next
+    next. (random 1654).next.next
+
+  ++> can-stay-in-range
+    and. > @
+      and.
+        and.
+          rand.lt 1
+          not.
+            rand.lt 0
+        and.
+          rand.next.lt 1
+          not.
+            rand.next.lt 0
+      and.
+        rand.next.next.lt 1
+        not.
+          rand.next.next.lt 0
+    next. > rand
+      random 123
+
+  ++> can-use-a-seed
+    not. > @
+      r.next.eq r.next.next
+    random 51 > r

--- a/objects/number/sine.eo
+++ b/objects/number/sine.eo
@@ -1,0 +1,138 @@
+# Sine of `num` radians as `org.eolang.number`.
+# The argument is reduced into the [-pi, pi] range and the Taylor series
+# is summed through Horner's scheme, so the result stays accurate for
+# angles of any magnitude, while non-finite arguments collapse to nan.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > sine
+  times. > @
+    minus. >> reduced
+      number num.as-bytes >> arg
+      times.
+        floor.
+          plus.
+            arg.div
+              pi.times 2 >> tau
+            0.5
+        tau
+    if. > [depth] >> factor
+      depth.gt 15
+      1
+      1.minus
+        times.
+          div.
+            reduced.times reduced
+            times.
+              depth.times 2
+              plus.
+                depth.times 2
+                1
+          factor
+            depth.plus 1
+    | 1
+
+  lt. ++> can-behave-as-an-odd-function
+    abs
+      times.
+        plus.
+          sine
+            pi.div 3
+          sine (pi.div 3).neg
+        1000
+    1
+
+  lt. ++> can-reduce-a-large-angle
+    abs
+      minus.
+        times.
+          sine
+            plus.
+              pi.times 10
+              pi.div 6
+          1000
+        500
+    1
+
+  lt. ++> can-take-a-sine-of-minus-pi-halves
+    abs
+      minus.
+        times.
+          sine (pi.div 2).neg
+          1000
+        -1000
+    1
+
+  lt. ++> can-take-a-sine-of-pi
+    abs
+      times.
+        sine pi
+        1000
+    1
+
+  lt. ++> can-take-a-sine-of-pi-halves
+    abs
+      minus.
+        times.
+          sine
+            pi.div 2
+          1000
+        1000
+    1
+
+  lt. ++> can-take-a-sine-of-pi-sixths
+    abs
+      minus.
+        times.
+          sine
+            pi.div 6
+          1000
+        500
+    1
+
+  lt. ++> can-take-a-sine-of-seventeen-radians
+    abs
+      minus.
+        times.
+          sine 17
+          1000
+        -961
+    1
+
+  lt. ++> can-take-a-sine-of-three-pi-halves
+    abs
+      minus.
+        times.
+          sine
+            div.
+              pi.times 3
+              2
+          1000
+        -1000
+    1
+
+  lt. ++> can-take-a-sine-of-two-pi
+    abs
+      times.
+        sine
+          pi.times 2
+        1000
+    1
+
+  eq. ++> can-take-a-sine-of-zero
+    sine 0
+    0
+
+  is-nan. ++> cannot-take-a-sine-of-nan
+    sine nan
+
+  is-nan. ++> cannot-take-a-sine-of-negative-infinity
+    sine ninf
+
+  is-nan. ++> cannot-take-a-sine-of-positive-infinity
+    sine pinf

--- a/objects/number/sqrt.eo
+++ b/objects/number/sqrt.eo
@@ -1,0 +1,73 @@
+# Positive square root of `num` as `org.eolang.number`, taken as `num` raised to
+# the one-half power. A negative argument, negative infinity included, is nan.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package number
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[num] > sqrt
+  if. > @
+    lt.
+      number num.as-bytes
+      0
+    nan
+    power
+      num
+      0.5
+
+  lt. ++> can-approximate-a-square-root-of-four
+    abs
+      2.minus
+        sqrt 4
+    1.0E-11
+
+  lt. ++> can-approximate-a-square-root-of-zero
+    abs
+      0.minus
+        sqrt 0
+    1.0E-11
+
+  lt. ++> can-take-a-square-root-of-a-half
+    abs
+      minus.
+        sqrt 0.25
+        0.5
+    1.0E-9
+
+  lt. ++> can-take-a-square-root-of-four
+    abs
+      minus.
+        sqrt 4
+        2
+    1.0E-9
+
+  eq. ++> can-take-a-square-root-of-one
+    sqrt 1
+    1
+
+  eq. ++> can-take-a-square-root-of-positive-infinity
+    sqrt pinf
+    pinf
+
+  lt. ++> can-take-a-square-root-of-two
+    abs
+      minus.
+        sqrt 2
+        1.4142135623730951
+    1.0E-9
+
+  eq. ++> can-take-a-square-root-of-zero
+    sqrt 0
+    0
+
+  is-nan. ++> cannot-take-a-square-root-of-a-negative
+    sqrt -0.1
+
+  is-nan. ++> cannot-take-a-square-root-of-nan
+    sqrt nan
+
+  is-nan. ++> cannot-take-a-square-root-of-negative-infinity
+    sqrt ninf

--- a/objects/os.eo
+++ b/objects/os.eo
@@ -1,0 +1,38 @@
+# Represents the current operating system.
+
++alias string.regex
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint redundant-object
+
+[] > os
+  name > @
+  as-bool. > is-linux
+    exists.
+      next.
+        match.
+          string.regex "/linux/i"
+          name
+  as-bool. > is-macos
+    exists.
+      next.
+        match.
+          string.regex "/mac/i"
+          name
+  as-bool. > is-windows
+    exists.
+      next.
+        match.
+          string.regex "/windows/i"
+          name
+  [] > name /Q.string
+
+  or. ++> can-check-the-os-family
+    os.is-windows.or os.is-macos
+    os.is-linux

--- a/objects/output.eo
+++ b/objects/output.eo
@@ -1,0 +1,15 @@
+# Output is an abstract destination of bytes that can be written sequentially.
+# Any output decorates the object bound to its `@` attribute, which must
+# provide a `write` object that takes the bytes to write and returns an
+# output block ready to write the next portion. See `output.dead` and
+# `chunk.to-output`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint unit-test-missing
+
+[@] > output

--- a/objects/output/dead.eo
+++ b/objects/output/dead.eo
@@ -1,0 +1,26 @@
+# Dead output is an output that writes to nowhere. Here `origin` is the
+# output this one is taken off, as in `o.dead`. It is ignored, because a
+# dead output writes to nowhere anyway.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package output
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[origin] > dead
+  [buffer] > write
+    [] >> output-block
+      true > @
+      output-block > [buffer] > write
+    | > @
+
+  malloc.of ++> can-be-taken-off-any-output
+    3
+    write. > [m]
+      dead.
+        output m.to-output
+      01-02-03
+
+  dead.write 01-02-03 ++> can-write-bytes-to-nowhere

--- a/objects/path.eo
+++ b/objects/path.eo
@@ -1,0 +1,511 @@
+# Path `path` that is hierarchical and composed of a sequence of
+# directory and file name elements separated by a special separator or delimiter.
+
++alias string.index-of
++alias string.last-index-of
++alias tuple.reduced
++alias string.regex
++alias string.replaced
++alias string.split
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[uri] > path
+  os.is-windows.if > @
+    win32
+      string uri.as-bytes
+    posix
+      string uri.as-bytes
+  [sys uri] > impl
+    uri > @
+    directory > as-dir
+      file uri
+    file uri > as-file
+    [] > basename
+      string > @
+        if.
+          or.
+            pth.size.eq 0
+            index.eq 0
+          uri >> pth!
+          as-bytes.
+            text.slice
+              plus. >> index!
+                string.last-index-of text separator
+                1
+              text.length.minus
+                number index
+      string pth > text
+    [] > dirname
+      string > @
+        if.
+          pth.size.eq 0
+          uri >> pth!
+          if.
+            len.eq -1
+            "."
+            if.
+              len.eq 0
+              separator
+              as-bytes.
+                text.slice
+                  0
+                  string.last-index-of text separator >> len!
+      string pth > text
+    sys.drive uri > drive
+    if. > driveless
+      drive.size.eq 0
+      uri
+      uri.slice
+        drive.size
+        uri.size.minus drive.size
+    [] > extname
+      if. > @
+        or.
+          or.
+            base.size.eq 0
+            index.eq -1
+          or.
+            index.eq 0
+            base.eq ".."
+        ""
+        string
+          as-bytes.
+            text.slice
+              string.last-index-of text "." >> index!
+              text.length.minus
+                number index
+      string > text
+        basename >> base!
+    is-root-relative.or > is-absolute
+      drive.size.gt 0
+    and. > is-root-relative
+      driveless.size.gt 0
+      eq.
+        driveless.slice 0 1
+        separator
+    [] > normalized
+      impl > @
+        sys
+        if.
+          normalized.eq
+            separator.concat separator
+          separator
+          if.
+            normalized.size.eq 0
+            "."
+            string normalized
+      as-bytes. > normalized
+        if.
+          driveless.size.eq 0
+          if.
+            drive.size.eq 0
+            "."
+            drive
+          concat.
+            concat.
+              drive.concat
+                is-root-relative.if separator --
+              string.joined >> body!
+                separator
+                tuple.reduced
+                  string.split driveless separator
+                  *
+                  if. > [accum segment] >>
+                    segment.eq ".."
+                    if.
+                      and.
+                        accum.length.gt 0
+                        not. (accum.head.eq "..")
+                      accum.tail
+                      is-root-relative.not.if (accum.with segment) accum
+                    if.
+                      or.
+                        segment.eq "."
+                        segment.eq ""
+                      accum
+                      accum.with segment
+            trailing.if separator --
+      and. > trailing
+        ubts.size.gt 0
+        eq.
+          slice.
+            uri >> ubts!
+            ubts.size.plus -1
+            1
+          separator
+    [other] > resolved
+      normalized. > @
+        impl
+          sys
+          string
+            if.
+              valid.size.eq 0
+              uri
+              if.
+                gt. (sys.drive valid).size 0
+                valid
+                if.
+                  eq.
+                    valid.slice 0 1
+                    separator
+                  drive.concat valid
+                  concat. (uri.concat separator) valid
+      string > valid!
+        as-bytes.
+          sys.sanitized other
+    sys.separator > separator
+  [paths] > joined
+    normalized. > @
+      os.is-windows.if
+        win32 jpath
+        posix jpath
+    string > jpath
+      as-bytes.
+        string.joined separator paths
+  [uri] > posix
+    impl > @
+      sys
+      uri
+    "/" > separator
+    [] > sys
+      -- > [uri] > drive
+      uri > [uri] > sanitized
+      ^.separator > separator
+  os.is-windows.if > separator
+    win32.separator
+    posix.separator
+  [uri] > win32
+    impl > @
+      sys
+      sys.sanitized uri
+    "\\" > separator
+    [] > sys
+      if. > [uri] > drive
+        as-bool. ((string.regex "/^[a-zA-Z]:/").match uri).next.exists
+        uri.slice 0 2
+        --
+      [uri] > sanitized
+        if. > @
+          eq.
+            string.index-of pth path.posix.separator
+            -1
+          string
+            uri >> ubts!
+          string (string.replaced pth (string.regex "/\\//") separator)!
+        string ubts > pth
+      ^.separator > separator
+
+  and. ++> can-detect-an-absolute-posix-path
+    is-absolute.
+      path.posix "/var/www/html"
+    not.
+      is-absolute.
+        path.posix "foo/bar/baz"
+
+  and. ++> can-detect-an-absolute-win32-path
+    and.
+      is-absolute.
+        path.win32 "C:\\Windows\\Users"
+      is-absolute.
+        path.win32 "\\Windows\\Users"
+    not.
+      is-absolute.
+        path.win32 "temp\\var"
+
+  path.separator.eq ++> can-determine-the-separator-from-the-os
+    os.is-windows.if
+      path.win32.separator
+      path.posix.separator
+
+  eq. ++> can-normalize-a-drive-only-win32-path
+    normalized.
+      path.win32 "C:"
+    "C:"
+
+  eq. ++> can-normalize-a-drive-relative-win32-path-keeping-a-leading-dotdot
+    normalized.
+      path.win32 "C:..\\foo"
+    "C:..\\foo"
+
+  eq. ++> can-normalize-a-path-to-the-root
+    normalized.
+      path.posix "/foo/bar/baz/../../../../"
+    "/"
+
+  eq. ++> can-normalize-a-posix-path
+    normalized.
+      path.posix "/foo/bar/.//./baz//../x/"
+    "/foo/bar/x/"
+
+  eq. ++> can-normalize-a-posix-path-collapsing-to-the-current-directory
+    normalized.
+      path.posix "foo/.."
+    "."
+
+  eq. ++> can-normalize-a-relative-posix-path
+    normalized.
+      path.posix "../../foo/./bar/../x/../y"
+    "../../foo/y"
+
+  eq. ++> can-normalize-a-relative-win32-path
+    normalized.
+      path.win32 "..\\..\\foo\\bar\\..\\x\\y\\\\"
+    "..\\..\\foo\\x\\y\\"
+
+  eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
+    normalized.
+      path.win32 "foo\\.."
+    "."
+
+  eq. ++> can-normalize-a-win32-path-down-to-a-drive-with-a-separator
+    normalized.
+      path.win32 "C:\\Windows\\.."
+    "C:\\"
+
+  eq. ++> can-normalize-a-win32-path-down-to-a-drive-without-a-separator
+    normalized.
+      path.win32 "C:hello\\.."
+    "C:"
+
+  eq. ++> can-normalize-a-win32-path-replacing-slashes
+    normalized.
+      path.win32 "/var/www/../html/"
+    "\\var\\html\\"
+
+  eq. ++> can-normalize-an-absolute-win32-path-with-a-drive
+    normalized.
+      path.win32 "C:\\Windows\\\\..\\Users\\.\\AppLocal"
+    "C:\\Users\\AppLocal"
+
+  eq. ++> can-normalize-an-absolute-win32-path-without-a-drive
+    normalized.
+      path.win32 "\\Windows\\Users\\..\\App\\\\.\\Local\\\\"
+    "\\Windows\\App\\Local\\"
+
+  eq. ++> can-normalize-an-empty-driveless-win32-path-to-the-current-directory
+    normalized.
+      path.win32 ""
+    "."
+
+  eq. ++> can-normalize-an-empty-posix-path-to-the-current-directory
+    normalized.
+      path.posix ""
+    "."
+
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-a-relative-path
+    resolved.
+      path.win32 "C:\\users\\local"
+      ".\\var\\temp"
+    "C:\\users\\local\\var\\temp"
+
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-a-root-relative-path
+    resolved.
+      path.win32 "C:\\users\\local"
+      "\\local\\var"
+    "C:\\local\\var"
+
+  eq. ++> can-resolve-a-drive-relative-win32-path-against-another-drive-relative-path
+    resolved.
+      path.win32 "C:\\users\\local"
+      "D:\\local\\var"
+    "D:\\local\\var"
+
+  eq. ++> can-resolve-a-posix-path-against-an-empty-one
+    resolved.
+      path.posix "/a/b"
+      ""
+    "/a/b"
+
+  eq. ++> can-resolve-a-relative-posix-path-against-an-absolute-path
+    resolved.
+      path.posix "./var/temp"
+      "/www/html"
+    "/www/html"
+
+  eq. ++> can-resolve-a-relative-posix-path-against-another-relative-path
+    resolved.
+      path.posix "./var/temp"
+      "../www/html"
+    "var/www/html"
+
+  eq. ++> can-resolve-a-relative-win32-path-against-a-drive-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      "C:\\Windows\\Users"
+    "C:\\Windows\\Users"
+
+  eq. ++> can-resolve-a-relative-win32-path-against-a-root-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      "\\Windows\\Users"
+    "\\Windows\\Users"
+
+  eq. ++> can-resolve-a-relative-win32-path-against-another-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      ".\\..\\x"
+    "temp\\x"
+
+  eq. ++> can-resolve-a-root-relative-win32-path-against-a-drive-relative-path
+    resolved.
+      path.win32 "\\users\\local"
+      "D:\\hello\\var"
+    "D:\\hello\\var"
+
+  eq. ++> can-resolve-a-root-relative-win32-path-against-a-relative-path
+    resolved.
+      path.win32 "\\users\\local"
+      ".\\hello\\var"
+    "\\users\\local\\hello\\var"
+
+  eq. ++> can-resolve-a-root-relative-win32-path-against-another-root-relative-path
+    resolved.
+      path.win32 "\\users\\local"
+      "\\hello\\var"
+    "\\hello\\var"
+
+  eq. ++> can-resolve-a-win32-path-against-an-empty-one
+    resolved.
+      path.win32 "C:\\a\\b"
+      ""
+    "C:\\a\\b"
+
+  eq. ++> can-resolve-an-absolute-posix-path-against-a-relative-path
+    resolved.
+      path.posix "/var/temp"
+      "./www/html"
+    "/var/temp/www/html"
+
+  eq. ++> can-resolve-an-absolute-posix-path-against-another-absolute-path
+    resolved.
+      path.posix "/var/temp"
+      "/www/html"
+    "/www/html"
+
+  eq. ++> can-return-a-basename-with-a-backslash-on-posix
+    basename.
+      path.posix "/var/www/html/foo\\bar"
+    "foo\\bar"
+
+  eq. ++> can-return-an-empty-basename-from-a-path-ending-with-a-separator
+    basename.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+          path.separator
+    ""
+
+  eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
+    dirname.
+      path.posix ".gitignore"
+    "."
+
+  eq. ++> can-return-the-current-dirname-of-a-relative-posix-file
+    dirname.
+      path.posix "plain"
+    "."
+
+  eq. ++> can-return-the-dirname-of-a-directory-path
+    dirname.
+      path.joined
+        *
+          "var"
+          "www"
+          path.separator
+    path.joined
+      * "var" "www"
+
+  eq. ++> can-return-the-dirname-of-a-file-path
+    dirname.
+      path.joined
+        *
+          "var"
+          "www"
+          "hello.text"
+    path.joined
+      * "var" "www"
+
+  eq. ++> can-return-the-dirname-of-a-file-path-without-an-extension
+    dirname.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+    path.joined
+      * "var" "www"
+
+  eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
+    dirname.
+      path.win32 "\\foo"
+    "\\"
+
+  eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path
+    dirname.
+      path.posix "/foo"
+    "/"
+
+  eq. ++> can-return-the-same-string-without-a-separator
+    basename.
+      path "Somebody"
+    "Somebody"
+
+  eq. ++> can-take-a-basename
+    basename.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+          "hello.eo"
+    "hello.eo"
+
+  eq. ++> can-take-a-file-extname
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "hello.text"
+    ".text"
+
+  eq. ++> can-take-an-extname-from-a-hidden-file-with-an-extension
+    extname.
+      path.posix ".config.json"
+    ".json"
+
+  eq. ++> cannot-take-an-extname-from-a-dotdot
+    extname.
+      path.posix ".."
+    ""
+
+  eq. ++> cannot-take-an-extname-from-a-dotfile
+    extname.
+      path.posix ".gitignore"
+    ""
+
+  eq. ++> cannot-take-an-extname-from-a-file-without-an-extension
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          "html"
+    ""
+
+  eq. ++> cannot-take-an-extname-from-a-path-ending-with-a-separator
+    extname.
+      path.joined
+        *
+          "var"
+          "www"
+          path.separator
+    ""

--- a/objects/pi.eo
+++ b/objects/pi.eo
@@ -1,0 +1,10 @@
+# Returns an approximate PI number.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+3.141592653589793 > pi

--- a/objects/pinf.eo
+++ b/objects/pinf.eo
@@ -1,11 +1,13 @@
+# Positive infinity.
+# A special floating-point value representing an unbounded quantity greater than all real numbers.
+# When dataized, it signifies an unbounded upper limit or an unreachable maximum value.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# Positive infinity.
-# A special floating-point value representing an unbounded quantity greater than all real numbers.
-# When dataized, it signifies an unbounded upper limit or an unreachable maximum value.
-number 7F-F0-00-00-00-00-00-00 > pinf
+number > pinf
+  7F-F0-00-00-00-00-00-00

--- a/objects/posix.eo
+++ b/objects/posix.eo
@@ -1,0 +1,116 @@
+# Makes a Unix syscall by `name` with POSIX interface.
+# Here `args` is a `org.eolang.tuple` of arguments required for
+# the particular syscall.
+# See the linux syscall [table](https://filippo.io/linux-syscall-table) for more info.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint redundant-object
+
+[name args] > posix
+  [] > @ /Q.posix.return
+  os.is-macos.if > append
+    8
+    1024
+  os.is-macos.if > creat
+    512
+    64
+  2 > inet
+  420 > mode
+  -1 > none
+  511 > permissions
+  0 > rdonly
+  2 > rdwr
+  [code output] > return
+    output > @
+    return > called
+      code
+      output
+  [family port address] > sockaddr-in
+    00-00-00-00-00-00-00-00 > padding
+    plus. > size
+      plus.
+        family.size.plus port.size
+        address.size
+      padding.size
+  [mode size] > stat
+  2 > stderr
+  0 > stdin
+  1 > stdout
+  1 > stream
+  6 > tcp
+  [seconds micros] > timeval
+  os.is-macos.if > trunc
+    1024
+    512
+  1 > wronly
+
+  ++> can-close-a-tcp-socket
+    os.is-windows.or > @
+      seq *
+        sd
+        not.
+          eq.
+            code.
+              posix *1
+                "close"
+                sd
+            -1
+    code. > sd
+      posix *1
+        "socket"
+        posix.inet
+        posix.stream
+        posix.tcp
+
+  os.is-windows.or ++> can-invoke-getpid
+    gt.
+      code.
+        posix
+          "getpid"
+          *
+      0
+
+  ++> can-open-a-tcp-socket
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "close"
+            sd
+        sd.gt 0
+    code. > sd
+      posix *1
+        "socket"
+        posix.inet
+        posix.stream
+        posix.tcp
+
+  ++> can-open-and-close-a-file-through-a-syscall
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "close"
+            fd
+        fd.gt -1
+    code. > fd
+      posix *1
+        "open"
+        "/dev/null"
+        0
+        0
+
+  os.is-windows.or ++> can-return-an-inet-address-for-localhost
+    eq.
+      code.
+        posix *1
+          "inet_addr"
+          "127.0.0.1"
+      16777343

--- a/objects/range.eo
+++ b/objects/range.eo
@@ -1,0 +1,108 @@
+# Range - create a `list` containing a range of elements
+# Here `start` must be an abstract object that must have an object `next` to get
+# next element and object `lt` to compare with the `end` object.
+# Every next element also must have objects `next` and `lt`.
+# The first object in the chain must have a default value
+# e.g.:
+#
+# ```
+# range
+#   []
+#     [num] > build
+#       num > @!
+#       build (@.plus 1) > next
+#     build 1 > @
+#   10
+# ```
+#
+# Here the first argument is an abstract object that has a default value - 1 and
+# it also has object `next`. The next object after first is decorator of
+# `1.plus 1` and also has object `next`. Since these objects are ints - they have
+# object `lt` by default.
+
++alias tuple.is-empty
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[start end] > range
+  if. > @
+    start.lt end
+    if. > [acc current] >> appended
+      current.lt end
+      appended
+        acc.with current
+        current.next
+      acc
+    |
+      * start
+      start.next
+    *
+
+  ++> can-build-a-range-from-one-to-ten
+    rng.eq > @
+      *
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+        8
+        9
+    range > rng
+      []
+        build 1 > @
+        [i] > build
+          i > @
+          build > next
+            1.plus @
+      10
+
+  ++> can-build-a-range-of-floats-from-one-to-five
+    rng.eq > @
+      *
+        1
+        1.5
+        2
+        2.5
+        3
+        3.5
+        4
+        4.5
+    range > rng
+      []
+        x 1 > @
+        [i] > x
+          i > @
+          x > next
+            0.5.plus @
+      5
+
+  ++> can-build-a-range-with-out-of-bounds-items
+    rng.eq > @
+      * 1 6
+    range > rng
+      []
+        b 1 > @
+        [num] > b
+          num > @
+          b > next
+            5.plus @
+      10
+
+  ++> can-build-an-empty-range-from-wrong-items
+    tuple.is-empty rng > @
+    range > rng
+      []
+        y 10 > @
+        [num] > y
+          num > @
+          [] > next
+            42 > nothing
+      1

--- a/objects/range/naturals.eo
+++ b/objects/range/naturals.eo
@@ -1,0 +1,53 @@
+# Range of natural numbers from `start` to `end` (soft border) with step = 1.
+# The `r` is an instance of `range`, which provides `start` and `end`.
+
++alias tuple.is-empty
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package range
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
+
+[r] > naturals
+  range > @
+    [] >>
+      build r.start > @
+      [num] > build
+        num > @
+        build > next
+          1.plus @
+    r.end
+
+  eq. ++> can-build-a-range-of-negatives
+    naturals
+      range -5 0
+    *
+      -5
+      -4
+      -3
+      -2
+      -1
+
+  tuple.is-empty ++> can-build-an-empty-range-from-ten-to-ten
+    naturals
+      range 10 10
+
+  tuple.is-empty ++> can-build-an-empty-range-when-descending
+    naturals
+      range 10 1
+
+  eq. ++> can-build-naturals-from-one-to-ten
+    naturals
+      range 1 10
+    *
+      1
+      2
+      3
+      4
+      5
+      6
+      7
+      8
+      9

--- a/objects/recovered.eo
+++ b/objects/recovered.eo
@@ -1,0 +1,50 @@
+# Recovers from a terminated computation.
+# Resolves `value` to its normal form; if that resolution terminates, behaves
+# as `alternative`, otherwise as `value`. This is the only way to intercept a
+# termination and keep going: one that is never recovered ends the program.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > recovered /A
+  ? > value /A?
+  ? > alternative /A
+
+  eq. ++> can-fall-back-to-the-alternative-when-terminated
+    recovered
+      2.as-i64.div 0.as-i64
+      7
+    7
+
+  eq. ++> can-keep-the-value-when-not-terminated
+    recovered
+      42
+      7
+    42
+
+  eq. ++> can-recover-an-inner-recovery
+    recovered
+      recovered
+        2.as-i64.div 0.as-i64
+        3.as-i64.div 0.as-i64
+      42
+    42
+
+  eq. ++> can-recover-when-a-provided-fallback-terminates
+    recovered
+      2.as-i64.div
+        0.as-i64
+        T > [message]
+          "cannot divide"
+      42
+    42
+
+  recovered --> stops-on-both-being-terminated
+    2.as-i64.div 0.as-i64
+    5.as-i64.div 0.as-i64

--- a/objects/seq.eo
+++ b/objects/seq.eo
@@ -1,10 +1,3 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-
 # Sequential execution object that dataizes all provided steps in order
 # and returns the value of the final step. All steps are dataized for
 # their side effects, while only the last step's value is returned.
@@ -17,6 +10,14 @@
 #   final-value     # Executed and returned
 # ```
 # .
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
 [steps] > seq
   if. > @
     steps.length.eq 0
@@ -24,187 +25,154 @@
     if.
       steps.length.eq 1
       steps.head
-      loop steps
-  steps.length.plus -1 > end!
+      if.
+        as-bool.
+          dataized
+            seq steps.tail
+        steps.head
+        steps.head
 
-  # Recursive steps dataization.
-  #
-  # Note: This object is intended for internal use only. Please
-  # do not use this object programmatically outside of the `seq` object.
-  [tup] > loop
-    if. > @
-      and.
-        tup.length.gt 1
-        loop tup.tail
-      tup.head
-      or.
-        (dataized tup.head).as-bool.eq --
-        tup.length.eq end
-
-  # Tests that seq step processing and final value return with float less than comparison.
-  [] +> tests-seq-single-dataization-float-less
-    malloc.of > @
+  eq. ++> can-calculate-and-return
+    1
+    seq *
+      0
       1
-      [b]
-        malloc.for > @
-          0.0
-          [m] >>
-            b.put > @
-              lt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1.0)
-                    m.as-number
-                1.1
 
-  # Tests that seq step processing and final value return with float greater than comparison.
-  [] +> tests-seq-single-dataization-float-greater
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0.0
-          [m] >>
-            b.put > @
-              gt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1.0)
-                    m.as-number
-                0.9
-
-  # Tests that seq step processing and final value return with integer less than comparison.
-  [] +> tests-seq-single-dataization-int-less
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          [m] >>
-            b.put > @
-              lt.
-                seq
-                  *
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                2
-
-  # Tests that seq step processing and final value return with integer than or equal comparison.
-  [] +> tests-seq-single-dataization-int-less-or-equal
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          [m] >>
-            b.put > @
-              lte.
-                seq
-                  *
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                1
-
-  # This test should have acceptable time to pass.
-  [] +> tests-very-long-seq
-    eq. > @
-      true
-      seq
-        *
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-          true
-
-  # Tests that seq correctly handles multiple memory operations and returns
-  # the last value when used with equality comparison.
-  [] +> tests-seq-single-dataization-int-equal-to-test
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          [m] >>
-            b.put > @
-              eq.
-                seq
-                  *
-                    m.put 0
-                    m.put (m.as-number.plus 1)
-                    m.as-number
-                1
-
-  # Tests that seq properly caches memory when processing array elements.
-  [] +> tests-seq-single-dataization-int-equal-to-cache-problem-test
-    malloc.of > @
-      1
-      [b]
-        malloc.for > @
-          0
-          [m] >>
-            b.put > @
-              eq.
-                seq
-                  *
-                    at.
-                      * 0 1
-                      m
-                    m.put (m.as-number.plus 1)
-                    m
-                1
-
-  # Tests that seq dataizes all steps except the last one and returns the last step's value.
-  [] +> tests-seq-calculates-and-returns
-    eq. > @
-      1
-      seq
-        *
-          0
-          1
-
-  # Tests that seq works correctly with object values (strings) as the final step.
-  [] +> tests-seq-calculates-and-returns-object
-    eq. > @
+  eq. ++> can-calculate-and-return-an-object
+    "Hello!"
+    seq *
+      0
       "Hello!"
-      seq
-        *
+
+  ++> can-dataize-a-float-once-when-greater
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
           0
-          "Hello!"
+          b.put > [m] >>
+            gt.
+              seq *
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              0.9
+
+  ++> can-dataize-a-float-once-when-less
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            lt.
+              seq *
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1.1
+
+  ++> can-dataize-an-integer-once-when-equal
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            eq.
+              seq *
+                m.put 0
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1
+
+  ++> can-dataize-an-integer-once-when-equal-and-cached
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            eq.
+              seq *
+                at.
+                  * 0 1
+                  m
+                m.put
+                  m.as-number.plus 1
+                m
+              1
+
+  ++> can-dataize-an-integer-once-when-less
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            lt.
+              seq *
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              2
+
+  ++> can-dataize-an-integer-once-when-less-or-equal
+    malloc.of > @
+      1
+      [b]
+        malloc.for > @
+          0
+          b.put > [m] >>
+            lte.
+              seq *
+                m.put
+                  m.as-number.plus 1
+                m.as-number
+              1
+
+  true.eq ++> can-run-a-very-long-sequence
+    seq *
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true
+      true

--- a/objects/set.eo
+++ b/objects/set.eo
@@ -1,0 +1,57 @@
+# Set - is an unordered `list` of unique objects.
+
++alias tuple.mapped
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[lst] > set
+  [mp] >> ctor
+    mp.keys > @
+    mp.has item > [item] > has
+    mp.size > size
+    set.ctor > [item] > with
+      mp.with item true
+    set.ctor > [item] > without
+      mp.without item
+  | > @
+    map
+      tuple.mapped
+        lst
+        map.entry item true > [item]
+
+  has. ++> can-append-a-new-item
+    with.
+      set *
+        1
+        2
+      3
+    3
+
+  eq. ++> cannot-append-an-existing-item
+    size.
+      with.
+        set *
+          1
+          2
+        1
+    2
+
+  eq. ++> can-have-a-size-of-zero-when-empty
+    size.
+      set
+        *
+    0
+
+  eq. ++> can-rebuild-itself
+    set *
+      1
+      2
+      2
+    *
+      1
+      2

--- a/objects/socket.eo
+++ b/objects/socket.eo
@@ -1,0 +1,271 @@
+# Socket.
+#
+# To connect to the local server as client you should do:
+#
+# ```
+# socket
+#   "127.0.0.1"                           # localhost IPv4 address
+#   8080                                  # port
+# .connect
+#   [s]
+#     s.send "Hello, world" > sent        # send message to the socket, `sent` - amount of sent bytes
+#     s.recv 12 > buff                    # receive 12 bytes from the socket, `buff` - received bytes
+#     s.as-input.read 5                   # make input from socket, `read` attribute is available
+#     s.as-output.write "Hi"              # make output from socket, `write` attribute is available
+# ```
+#
+# When you dataize `socket.connect`, it creates new socket, connects to the given
+# IP on given port, dataizes provided scope, closes the socket and returns bytes
+# retrieved from scope dataization. On failure at any of the described steps, the fallback of the
+# corresponding operation is returned (or the bottom object when it is left unbound).
+#
+# To listen to the incoming connections as server you should do:
+#
+# ```
+# socket
+#   "127.0.0.1"
+#   8080
+# .listen
+#   [s]
+#     s.accept                             # accept incoming connection on socket,
+#       [client]                           # client is connected client socket
+#         client.send "Hi, Jeff"           # returns client socket, that has all the attributes
+#         client.recv 42                   # of the scoped-socket (except "accept" attribute)
+#         client.as-input.read 5           # same as in `socket.connect`
+#         client.as-output.write "Hi"      # same as in `socket.connect`
+# ```
+#
+# When you dataize `socket.listen`, it creates new socket, binds it to the given address and port,
+# starts listening for incoming connections, dataizes provided scope, closes the socket
+# and returns `bytes` retrieved from scope dataization. When `s.accept` is dataized - it dataizes
+# given scope, closes client socket and returns `bytes` retrieved from scope dataization.
+# On failure at any of the described steps, the fallback of the corresponding operation is
+# returned (or the bottom object when it is left unbound).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint unit-test-missing
++unlint redundant-object
++unlint mandatory-package
+
+[address port] > socket
+  os.is-windows.if > @
+    [sys] >> impl
+      code. > addr
+        sys.raw *1
+          "inet_addr"
+          address
+      addr.as-i32 > addrint
+      [descriptor] > closed-socket
+        if. > @
+          closed.eq -1
+          T
+            "Couldn't close the socket #%d because %s".printf
+              * descriptor sys.message
+          true
+        code. > closed
+          sys.raw *1
+            sys.close
+            descriptor
+      [scope cant-connect] > connect
+        safe-socket > @
+          [] >>
+            if. > @
+              connected.eq -1
+              cant-connect
+                "Couldn't connect to %s:%d on socket #%d because %s".printf
+                  * sock.address sock.port sock.sd sock.sys.message
+              scope
+                sock.scoped-socket sock.sd
+            code. > connected
+              sock.sys.raw *1
+                "connect"
+                sock.sd
+                sock.sockaddr
+                sock.sockaddr.size
+            ^.^.^ > sock
+          cant-connect
+      [scope cant-listen] > listen
+        safe-socket > @
+          [] >>
+            if. > @
+              bound.eq -1
+              cant-listen
+                "Couldn't bind the socket #%d to %s:%d because %s".printf
+                  * sock.sd sock.address sock.port sock.sys.message
+              if.
+                listened.eq -1
+                cant-listen
+                  "Failed to listen to %s:%d on the socket #%d because %s".printf
+                    * sock.address sock.port sock.sd sock.sys.message
+                scope
+                  [] >>
+                    sock.scoped-socket sock.sd > @
+                    [scope cant-accept] > accept
+                      if. > @
+                        client.eq -1
+                        cant-accept
+                          "Failed to accept a connection on the socket #%d because %s".printf
+                            * sock.sd sock.sys.message
+                        seq *
+                          scope (sock.scoped-socket client) >> handled!
+                          sock.closed-socket client
+                          handled
+                      code. > client
+                        sock.sys.raw *1
+                          "accept"
+                          sock.sd
+                          sock.sockaddr
+                          sock.sockaddr.size
+            code. > bound
+              sock.sys.raw *1
+                "bind"
+                sock.sd
+                sock.sockaddr
+                sock.sockaddr.size
+            code. > listened
+              sock.sys.raw *1
+                "listen"
+                sock.sd
+                2048
+            ^.^.^ > sock
+          cant-listen
+      [scope cant] > safe-socket
+        if. > @
+          not.
+            sys.startup.eq 0
+          cant
+            "Couldn't start up the sockets subsystem because %s".printf
+              * sys.message
+          seq *
+            if. >> result!
+              sd.eq -1
+              cant
+                "Couldn't create a socket because %s".printf
+                  * sys.message
+              seq *
+                if. >> used!
+                  addr.eq sys.none
+                  cant
+                    "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
+                      * address sys.message
+                  scope
+                closed-socket sd
+                used
+            sys.cleanup
+            result
+      [descriptor] > scoped-socket
+        ^.^.as-input recv > as-input
+        ^.^.as-output send > as-output
+        [size cant-receive] > recv
+          if. > @
+            received.code.eq -1
+            cant-receive
+              "Failed to receive data from the socket #%d because %s".printf
+                * descriptor sys.message
+            received.output
+          called. > received
+            sys.raw *1
+              "recv"
+              descriptor
+              size
+              0
+        [buffer cant-send] > send
+          if. > @
+            sent.eq -1
+            cant-send
+              "Failed to send a message through the socket #%d because %s".printf
+                * descriptor sys.message
+            sent
+          code. > sent
+            sys.raw *1
+              "send"
+              descriptor
+              buffer >> buff!
+              buff.size
+              0
+      code. > sd
+        sys.raw *1
+          "socket"
+          sys.inet
+          sys.stream
+          sys.tcp
+      sys.sockaddr-in > sockaddr
+        sys.inet.as-i16
+        htons port
+        addrint
+    |
+      []
+        raw > @
+        if. > cleanup
+          eq.
+            code.
+              win32
+                "WSACleanup"
+                *
+            win32.failure
+          T
+            "Couldn't clean up the sockets subsystem"
+          true
+        "closesocket" > close
+        "WSA error code %d".printf > message
+          *
+            code.
+              win32
+                "WSAGetLastError"
+                *
+        win32 > raw
+        code. > startup
+          win32 *1
+            "WSAStartup"
+            win32.version
+    impl
+      []
+        raw > @
+        true > cleanup
+        "close" > close
+        code. > message
+          posix *1
+            "strerror"
+            code.
+              posix
+                "errno"
+                *
+        posix > raw
+        0 > startup
+  [recv] > as-input
+    [size] > read
+      @. > @
+        read.
+          input-block --
+          size
+      [buffer] > input-block
+        buffer > @
+        [size] > read
+          seq * > @
+            chunk
+            input-block chunk
+          as-bytes. > chunk
+            recv size
+  [send] > as-output
+    [buffer] > write
+      @. > @
+        output-block.write buffer
+      [] > output-block
+        true > @
+        seq * > [buffer] > write
+          send buffer
+          output-block
+  [port] > htons
+    as-i16. > @
+      or.
+        left.
+          b.and 00-FF
+          8
+        and.
+          b.right 8
+          00-FF
+    port.as-i16.as-bytes > b

--- a/objects/stderr.eo
+++ b/objects/stderr.eo
@@ -1,0 +1,58 @@
+# Convenient wrapper `stderr` which uses the operating system console
+# as an error output only and allows to print the given argument to the
+# standard error stream as `string`:
+# ```
+# [args] > app
+#   Q.stderr > @
+#     "Something went wrong!\n"
+# ```
+#
+# Here the "Something went wrong!" string is printed to the operating
+# system standard error stream (file descriptor 2). The object writes to
+# the console in a platform-specific way, with different implementations
+# for POSIX and Windows systems.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[text] > stderr
+  seq * > @
+    write.
+      os.is-windows.if
+        [] >>
+          [buffer] > write
+            @. > @
+              output-block.write buffer
+            [] > output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  win32 *1
+                    "_write"
+                    win32.stderr
+                    buffer
+                    buffer.size
+                output-block
+        [] >>
+          [buffer] > write
+            @. > @
+              output-block.write buffer
+            [] > output-block
+              true > @
+              seq * > [buffer] > write
+                code.
+                  posix *1
+                    "write"
+                    posix.stderr
+                    buffer
+                    buffer.size
+                output-block
+      text
+    true
+
+  stderr ++> can-print-to-stderr
+    "Hello, stderr-test!\n"

--- a/objects/stdin.eo
+++ b/objects/stdin.eo
@@ -1,0 +1,65 @@
+# Convenient wrapper `stdin` on `console` object
+# which is used as input only and allows to read the data from console.
+#
+# To read just one line you can do:
+# ```
+# stdin.next-line
+# ```
+#
+# To read all lines you can do:
+# ```
+# stdin.all-lines
+# ```
+#
+# or just dataize `stdin` object.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++unlint unit-test-missing
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[] > stdin
+  all-lines > @
+  [] > all-lines
+    [line buffer first] >> rec-read
+      if. > @
+        line.length.eq 0
+        string buffer
+        rec-read
+          next-line
+          first.if
+            buffer.concat line
+            concat.
+              buffer.concat eol!
+              line
+          false
+    | > @
+      next-line
+      --
+      true
+  [] > next-line
+    if. > @
+      first.as-bytes.size.eq 0
+      ""
+      [input buffer] >> rec-read
+        if. > @
+          or.
+            char.eq --
+            or.
+              and.
+                char.eq "\r"
+                next.as-bytes.eq "\n"
+              char.eq "\n"
+          string buffer
+          rec-read
+            next
+            buffer.concat char
+        input.as-bytes > char
+        @. > next
+          input.read 1
+      | first --
+    @. > first
+      console.read 1

--- a/objects/stdout.eo
+++ b/objects/stdout.eo
@@ -1,0 +1,24 @@
+# Convenient wrapper `stdout` on `console` object which
+# uses it as output only and allows to print the given argument to console as `string`:
+# ```
+# [args] > app
+#   Q.stdout > @
+#     "Hello, world!\n"
+# ```
+#
+# Here the "Hello, world!" string is printed to the operating system console.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
+[text] > stdout
+  seq * > @
+    console.write text
+    true
+
+  stdout ++> can-print-to-the-console
+    "Hello, stdout-test!\n"

--- a/objects/string.eo
+++ b/objects/string.eo
@@ -1,13 +1,4 @@
-+alias tt.sprintf
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
-
-# The `string` object represents UTF-8 encoded text strings stored internally
+# Object `string` represents UTF-8 encoded text strings stored internally
 # as byte sequences. It provides Unicode-aware operations for text manipulation
 # including slicing, length calculation, and character-level access.
 # Unicode characters may occupy 1-4 bytes each, so byte length differs from
@@ -20,424 +11,114 @@
 # "text".slice 0 2               # Character-based slicing
 # ```
 # .
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
 [as-bytes] > string
   as-bytes > @
 
-  # Calculates the length of the string.
-  [] > length
-    if. > @
-      size.eq 0
-      0
-      reclen 0 0
-    as-bytes.size > size
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
+  string.contains ++> can-check-containment-through-the-package
+    "hello, world"
+    "world"
 
-    # The object checks if `index` + `csize` is out of the string bounds.
-    # If not - the new recursion iteration is started with `index` increased by `csize` and
-    # `accum` increased by 1.
-    [index csize len] > inclen
-      if. > @
-        (index.plus csize).gt size
-        error
-          sprintf
-            "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
-            * csize index as-bytes
-        reclen
-          index.plus csize
-          len.plus 1
+  not. ++> can-compare-a-string-with-nan
+    nan.eq "друг"
 
-    # The object recursively calculates the length of current string considering how many bytes
-    # the character on each iteration must consist of.
-    [index accum] > reclen
-      if. > @
-        index.eq size
-        accum
-        if.
-          (byte.and p1).eq r1
-          inclen index 1 accum
-          if.
-            (byte.and p2).eq r2
-            inclen index 2 accum
-            if.
-              (byte.and p3).eq r3
-              inclen index 3 accum
-              if.
-                (byte.and p4).eq r4
-                inclen index 4 accum
-                error
-                  sprintf
-                    "Unknown byte format (%x), can't recognize character"
-                    * byte
-      as-bytes.slice index 1 > byte
+  not. ++> can-compare-a-string-with-negative-infinity
+    ninf.eq "друг"
 
-  # Takes a piece of a string as another string.
-  [start len] > slice
-    if. > @
-      nstart.lt 0
-      error
-        sprintf
-          "Start index must be >= 0, but was %d"
-          * nstart
-      if.
-        nlen.lt 0
-        error
-          sprintf
-            "Length to slice must be >= 0, but was %d"
-            * nlen
-        if.
-          nlen.eq 0
-          ""
-          string
-            as-bytes.slice bstart blen
-    start > sbts!
-    len > lbts!
-    number sbts > nstart
-    number lbts > nlen
-    as-bytes.size > size
-    nstart.plus nlen > end
-    80- > p1
-    E0- > p2
-    F0- > p3
-    F8- > p4
-    00- > r1
-    C0- > r2
-    p2 > r3
-    p3 > r4
-    recidx > bstart!
-      0
-      0
-      nstart
-      sprintf
-        "Start index (%d) is out of string bounds"
-        * nstart
-    minus. > blen
-      recidx
-        number bstart
-        0
-        nlen
-        sprintf
-          "Start index + length to slice (%d) is out of string bounds"
-          * (nstart.plus nlen)
-      bstart
+  eq. ++> can-compare-a-string-with-positive-infinity
+    pinf.eq "друг"
+    false
 
-    # The object checks if `index` + `csize` is not out of the string bounds.
-    # If not - the new recursion cycle is started with `index` increased by `csize` and
-    # `accum` increased by 1.
-    [index csize accum result cause] > increase
-      if. > @
-        (index.plus csize).gt size
-        error
-          sprintf
-            "Expected %d byte character at %d index, but there are not enough bytes for it: %x"
-            * csize index as-bytes
-        recidx
-          index.plus csize
-          accum.plus 1
-          result
-          cause
+  "Ф".eq "Ф" ++> can-compare-one-symbol-strings
 
-    # The object recursively calculates `index` of bytes representation of the string
-    # where `accum` equals provided `result`.
-    # The `cause` here is the description of the error which is thrown when `index` reaches the end
-    # of the bytes but `accum` does not reach the `result`.
-    # Also it checks how many bytes (B) must contain character on the current step and tries to
-    # increase index by B.
-    [index accum result cause] > recidx
-      if. > @
-        accum.eq result
-        index
-        if.
-          index.eq size
-          error cause
-          if.
-            (byte.and p1).eq r1
-            increase index 1 accum result cause
-            if.
-              (byte.and p2).eq r2
-              increase index 2 accum result cause
-              if.
-                (byte.and p3).eq r3
-                increase index 3 accum result cause
-                if.
-                  (byte.and p4).eq r4
-                  increase index 4 accum result cause
-                  error
-                    sprintf
-                      "Unknown byte format (%x), can't recognize character"
-                      * byte
-      as-bytes.slice index 1 > byte
+  not. ++> can-compare-two-different-string-types
+    "Hello".eq 42
 
-  # Tests that string length calculation works correctly for a single space character.
-  [] +> tests-calculates-length-of-spaces-only
-    eq. > @
-      " ".length
-      1
+  not. ++> can-compare-two-different-strings
+    "Hello".eq
+      "Good bye"
 
-  # Tests that string can be converted to its byte representation with Unicode characters.
-  [] +> tests-turns-string-into-bytes
-    eq. > @
-      "€ друг".as-bytes
-      E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
+  eq. ++> can-compare-two-equal-strings
+    "x".eq "x"
+    true
 
-  # Tests that byte sequence equals string with Cyrillic characters.
-  [] +> tests-bytes-equal-to-string
-    eq. > @
-      D0-B4-D1-80-D1-83-D0-B3
-      "друг"
+  contains. ++> can-contain-a-word-in-a-sentence
+    "hello, world, how are you?"
+    "how"
 
-  # Tests that string with Cyrillic characters equals byte sequence.
-  [] +> tests-string-equals-to-bytes
-    eq. > @
-      "друг"
-      D0-B4-D1-80-D1-83-D0-B3
+  "eEo".is-alpha ++> can-detect-alphabetic-text
 
-  # Tests that string length is calculated correctly for 2-byte UTF-8 characters.
-  [] +> tests-reads-the-length-with-n2-byte-characters
-    and. > @
-      str.length.eq 12
-      str.as-bytes.size.eq 16
-    "Hello, друг!" > str
+  "2026".is-digit ++> can-detect-digits
 
-  # Tests that string length is calculated correctly for 3-byte UTF-8 characters.
-  [] +> tests-reads-the-length-with-n3-byte-characters
-    and. > @
-      str.length.eq 16
-      str.as-bytes.size.eq 18
-    "The अ devanagari" > str
+  ends-with. ++> can-end-with-a-suffix
+    "hello, world"
+    "world"
 
-  # Tests that string length is calculated correctly for 4-byte UTF-8 characters.
-  [] +> tests-reads-the-length-with-n4-byte-characters
-    and. > @
-      str.length.eq 11
-      str.as-bytes.size.eq 14
-    "The 😀 smile" > str
+  D0-B4-D1-80-D1-83-D0-B3.eq "друг" ++> can-equal-a-string-through-bytes
 
-  # Tests that string length calculation throws error for incomplete 4-byte UTF-8 character.
-  # The smile emoji is F0-9F-98-80 in bytes. Here we check if string.length fails if it faces
-  # incomplete 4 byte character.
-  [] +> throws-on-taking-length-of-incomplete-n4-byte-character
-    (string F0-9F-98).length > @
+  "друг".eq D0-B4-D1-80-D1-83-D0-B3 ++> can-equal-bytes
 
-  # Tests that string comparison with different data type returns false.
-  [] +> tests-compares-two-different-string-types
-    not. > @
-      eq.
-        "Hello"
-        42
+  eq. ++> can-find-the-index-of-a-character
+    "hello".index-of "l"
+    2
 
-  # Tests that string comparison with NaN value returns false.
-  [] +> tests-compares-string-with-nan
-    not. > @
-      eq.
-        nan
-        "друг"
+  "Abc".eq "Abc" ++> can-hold-a-one-line-text-block
 
-  # Tests that string comparison with positive infinity returns false.
-  [] +> tests-compares-string-with-positive-infinity
-    eq. > @
-      pinf.eq "друг"
-      false
+  eq. ++> can-hold-a-text-block-with-a-margin
+    "z\n  y\n x"
+    7A-0A-20-20-79-0A-20-78
 
-  # Tests that string comparison with negative infinity returns false.
-  [] +> tests-compares-string-with-negative-infinity
-    not. > @
-      eq.
-        ninf
-        "друг"
+  "e\ne\ne".eq 65-0A-65-0A-65 ++> can-hold-a-three-line-text-block
 
-  # Tests that single-line text block equals regular string.
-  [] +> tests-text-block-one-line
-    eq. > @
-      """
-      Abc
-      """
-      "Abc"
+  "HELLO".low-cased.eq "hello" ++> can-lower-case-text
 
-  # Tests that multi-line text block produces correct byte sequence.
-  [] +> tests-text-block-tree-lines
-    eq. > @
-      """
-      e
-      e
-      e
-      """.as-bytes
-      65-0A-65-0A-65
+  eq. ++> can-preserve-indentation-in-a-text-block
+    "a\n b\n  c"
+    "a\n b\n  c"
 
-  # Tests that text block preserves indentation and produces correct byte sequence.
-  [] +> tests-text-block-with-margin
-    eq. > @
-      """
-       z
-        y
-       x
-      """.as-bytes
-      7A-0A-20-20-79-0A-20-78
+  eq. ++> can-repeat-text
+    "ha".repeated 3
+    "hahaha"
 
-  # Tests that comparison of two different strings returns false.
-  [] +> tests-compares-two-different-strings
-    not. > @
-      eq.
-        "Hello"
-        "Good bye"
+  starts-with. ++> can-start-with-a-prefix
+    "hello, world"
+    "hello"
 
-  # Tests that Unicode escape sequences are correctly converted to characters.
-  [] +> tests-supports-escape-sequences
-    eq. > @
-      "Hello, \u0434\u0440\u0443\u0433!\n"
-      "Hello, друг!\n"
+  "\n".eq "\n" ++> can-support-a-line-break-escape-sequence
 
-  # Tests that Unicode escape sequences work correctly in text blocks.
-  [] +> tests-supports-escape-sequences-in-text
-    eq. > @
-      """
-      Hello, \u0434\u0440\u0443\u0433!\n
-      """
-      "Hello, друг!\n"
+  "Ф".eq "Ф" ++> can-support-a-unicode-escape-sequence
 
-  # Tests that text blocks preserve indentation correctly.
-  [] +> tests-preserves-indentation-in-text
-    eq. > @
-      """
-      a
-       b
-        c
-      """
-      "a\n b\n  c"
+  eq. ++> can-support-escape-sequences
+    "Hello, друг!\n"
+    "Hello, друг!\n"
 
-  # Tests that comparison of two identical strings returns true.
-  [] +> tests-compares-two-strings
-    eq. > @
-      eq.
-        "x"
-        "x"
-      true
+  eq. ++> can-support-escape-sequences-in-a-text-block
+    "Hello, друг!\n"
+    "Hello, друг!\n"
 
-  # Tests that single Unicode character string comparison works correctly.
-  [] +> tests-one-symbol-string-compares
-    eq. > @
-      "Ф"
-      "Ф"
+  eq. ++> can-take-a-character-at-an-index
+    "some".at 1
+    "o"
 
-  # Tests that line break escape sequences are equivalent.
-  [] +> tests-supports-escape-sequences-line-break
-    eq. > @
-      "\n"
-      "\012"
+  eq. ++> can-trim-surrounding-spaces
+    "  spaced  ".trimmed
+    "spaced"
 
-  # Tests that Unicode escape sequence equals actual Unicode character.
-  [] +> tests-supports-escape-sequences-unicode
-    eq. > @
-      "\u0424"
-      "Ф"
+  eq. ++> can-turn-into-bytes
+    "€ друг".as-bytes
+    E2-82-AC-20-D0-B4-D1-80-D1-83-D0-B3
 
-  # Tests that string slicing from the beginning works correctly.
-  [] +> tests-slice-from-start
-    eq. > @
-      "hello".slice 0 1
-      "h"
+  eq. ++> can-unescape-slashes
+    "x\\b\\f\\u\\r\\t\\n\\'"
+    78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
 
-  # Tests that string slicing from middle position works correctly.
-  [] +> tests-slice-in-the-middle
-    eq. > @
-      "hello".slice 2 3
-      "llo"
+  "\b\f\n\r\t⟦".eq 08-0C-0A-0D-09-E2-9F-A6 ++> can-unescape-symbols
 
-  # Tests that string slicing from near the end works correctly.
-  [] +> tests-slice-from-the-end
-    eq. > @
-      "hello".slice 4 1
-      "o"
-
-  # Tests that slicing empty string returns empty string.
-  [] +> tests-slice-empty-string
-    eq. > @
-      "".slice 0 0
-      ""
-
-  # Tests that slicing with zero length returns empty string.
-  [] +> tests-no-slice-string
-    eq. > @
-      "no slice".slice 0 0
-      ""
-
-  # Tests that slicing line break escape sequence works correctly.
-  [] +> tests-slice-escape-sequences-line-break
-    eq. > @
-      "\n".slice
-        0
-        "\n".length
-      "\012"
-
-  # Tests that slicing Unicode escape sequence works correctly.
-  [] +> tests-slice-escape-sequences-unicode
-    eq. > @
-      "\u0424".slice
-        0
-        "\u0424".length
-      "Ф"
-
-  # Tests that string slicing works correctly with 2-byte UTF-8 characters.
-  [] +> tests-slice-with-n2-byte-characters
-    eq. > @
-      "привет".slice 1 2
-      "ри"
-
-  # Tests that string slicing works correctly with 3-byte UTF-8 characters.
-  [] +> tests-slice-with-n3-byte-characters
-    eq. > @
-      "The अ is अ".slice 1 6
-      "he अ i"
-
-  # Tests that string slicing works correctly with 4-byte UTF-8 characters.
-  [] +> tests-slice-with-n4-byte-characters
-    eq. > @
-      "One 😀 and 😀 another".slice 3 8
-      " 😀 and 😀"
-
-  # Tests that string slicing works correctly with Chinese characters.
-  [] +> tests-slice-foreign-literals
-    eq. > @
-      "hello, 大家!".slice
-        7
-        1
-      "大"
-
-  # Tests that slicing throws error when start index is negative.
-  [] +> throws-on-slicing-start-below-zero
-    slice. > @
-      "some string"
-      -1
-      1
-
-  # Tests that slicing throws error when length is negative.
-  [] +> throws-on-slicing-end-below-start
-    slice. > @
-      "some string"
-      2
-      -1
-
-  # Tests that slicing throws error when requested slice exceeds string bounds.
-  [] +> throws-on-slicing-end-greater-actual
-    slice. > @
-      "some string"
-      7
-      5
-
-  # Tests that the runtime unescapes slashes in strings.
-  [] +> tests-unescapes-slashes
-    eq. > @
-      "x\\b\\f\\u\\r\\t\\n\\'"
-      78-5C-62-5C-66-5C-75-5C-72-5C-74-5C-6E-5C-27
-
-  # Tests that the runtime unescapes symbols in strings.
-  [] +> tests-unescapes-symbols
-    eq. > @
-      "\b\f\n\r\t\u27E6"
-      08-0C-0A-0D-09-E2-9F-A6
+  "hello".up-cased.eq "HELLO" ++> can-upper-case-text

--- a/objects/string/as-ascii.eo
+++ b/objects/string/as-ascii.eo
@@ -1,0 +1,52 @@
+# Reads the single character `char` as its ASCII numeric value (0-255).
+# The byte of `char` is left-padded with a zero byte into a 16-bit word,
+# read as an integer and then expressed as a number.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[char] > as-ascii
+  as-number. > @
+    as-i16.
+      00-.concat char.as-bytes
+
+  eq. ++> can-read-the-code-of-a-lowercase-letter
+    97
+    as-ascii "a"
+
+  eq. ++> can-read-the-code-of-a-punctuation-mark
+    33
+    as-ascii "!"
+
+  eq. ++> can-read-the-code-of-a-space
+    32
+    as-ascii
+      " "
+
+  eq. ++> can-read-the-code-of-an-uppercase-letter
+    65
+    as-ascii "A"
+
+  eq. ++> can-read-the-code-of-the-last-lowercase-letter
+    122
+    as-ascii "z"
+
+  eq. ++> can-read-the-code-of-the-last-printable-character
+    126
+    as-ascii "~"
+
+  eq. ++> can-read-the-code-of-the-last-uppercase-letter
+    90
+    as-ascii "Z"
+
+  eq. ++> can-read-the-code-of-the-nine-digit
+    57
+    as-ascii "9"
+
+  eq. ++> can-read-the-code-of-the-zero-digit
+    48
+    as-ascii "0"

--- a/objects/string/as-char.eo
+++ b/objects/string/as-char.eo
@@ -1,0 +1,50 @@
+# Writes the ASCII `code` (0-255) as its single byte, the inverse of `as-ascii`.
+# The number is read as a 64-bit integer and its least-significant byte is taken.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[code] > as-char
+  code.as-i64.as-bytes.slice > @
+    7
+    1
+
+  eq. ++> can-round-trip-through-as-ascii
+    "!"
+    string
+      as-char
+        as-ascii "!"
+
+  eq. ++> can-write-the-byte-of-a-lowercase-letter
+    "z"
+    string
+      as-char 122
+
+  eq. ++> can-write-the-byte-of-a-space
+    " "
+    string
+      as-char 32
+
+  eq. ++> can-write-the-byte-of-an-uppercase-letter
+    "A"
+    string
+      as-char 65
+
+  eq. ++> can-write-the-byte-of-the-last-printable-character
+    "~"
+    string
+      as-char 126
+
+  eq. ++> can-write-the-byte-of-the-last-uppercase-letter
+    "Z"
+    string
+      as-char 90
+
+  eq. ++> can-write-the-byte-of-the-zero-digit
+    "0"
+    string
+      as-char 48

--- a/objects/string/as-decimal.eo
+++ b/objects/string/as-decimal.eo
@@ -1,0 +1,89 @@
+# Writes the number `n` as signed decimal digits, truncating its fraction
+# towards zero, so that `42.7` becomes `42` and `-42.7` becomes `-42`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n] > as-decimal
+  n.is-finite.not.if > @
+    T
+      "Can't write a non-finite number as decimal"
+    if.
+      n.lt 0
+      if. > [m] >> negative
+        m.floor.eq 0
+        digits m
+        "-".as-bytes.concat
+          digits m
+      | (n.times -1)
+      [n] >> digits
+        if. > @
+          n.lt 10
+          as-char
+            n.floor.plus 48
+          concat.
+            digits q
+            as-char
+              plus.
+                floor.
+                  n.minus
+                    q.times 10
+                48
+        floor. > q
+          n.div 10
+      | n
+
+  eq. ++> can-drop-the-sign-of-a-negative-below-one
+    "0"
+    string
+      as-decimal -0.9
+
+  eq. ++> can-drop-the-sign-of-a-negative-truncating-to-zero
+    "0"
+    string
+      as-decimal -0.5
+
+  eq. ++> can-truncate-a-negative-fraction
+    "-7"
+    string
+      as-decimal -7.89
+
+  eq. ++> can-truncate-a-positive-fraction
+    "42"
+    string
+      as-decimal 42.987
+
+  eq. ++> can-write-a-multi-digit-number
+    "31415"
+    string
+      as-decimal 31415
+
+  eq. ++> can-write-a-negative-number
+    "-42"
+    string
+      as-decimal -42
+
+  eq. ++> can-write-a-number-with-an-inner-zero
+    "105"
+    string
+      as-decimal 105
+
+  eq. ++> can-write-a-single-digit
+    "7"
+    string
+      as-decimal 7
+
+  eq. ++> can-write-zero
+    "0"
+    string
+      as-decimal 0
+
+  as-decimal nan --> stops-on-nan
+
+  as-decimal ninf --> stops-on-negative-infinity
+
+  as-decimal pinf --> stops-on-positive-infinity

--- a/objects/string/as-fixed.eo
+++ b/objects/string/as-fixed.eo
@@ -1,0 +1,168 @@
+# Writes the number `n` as fixed-point decimal with exactly `places` fraction
+# digits, rounding to the nearest unit in the last place, so that `2.5` with
+# four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
+# If `places` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-print` fallback is returned, or the bottom object
+# when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n places cant-print] > as-fixed
+  if. > @
+    or.
+      0.gt places
+      places.is-integer.not
+    cant-print
+      "Can't write a fixed-point decimal with %f fraction places".printf
+        * places
+    if.
+      n.lt 0
+      if. > [a] >> signed
+        eq.
+          floor.
+            plus.
+              a.times
+                pow10 places
+              0.5
+          0
+        positive a
+        "-".as-bytes.concat
+          positive a
+      | (n.times -1)
+      [a] >> positive
+        if. > @
+          places.eq 0
+          as-decimal ip
+          concat.
+            concat.
+              as-decimal ip
+              ".".as-bytes
+            rec-pad
+              m.minus
+                ip.times scale
+              places
+              --
+        floor. > ip
+          m.div scale
+        floor. > m
+          plus.
+            a.times scale
+            0.5
+        pow10 places > scale
+      | n
+  if. > [p] >> pow10
+    p.eq 0
+    1
+    times.
+      pow10
+        as-number.
+          p.minus 1
+      10
+  if. > [value count acc] >> rec-pad
+    count.eq 0
+    acc
+    rec-pad
+      floor.
+        value.div 10
+      as-number.
+        count.minus 1
+      concat.
+        as-char
+          plus.
+            floor.
+              value.minus
+                times. (value.div 10).floor 10
+            48
+        acc
+
+  eq. ++> can-carry-rounding-into-the-integer-part
+    "1.000000"
+    string
+      as-fixed 0.9999999 6
+
+  eq. ++> can-drop-the-sign-of-a-negative-rounding-to-zero
+    "0.00"
+    string
+      as-fixed -1.0E-4 2
+
+  eq. ++> can-drop-the-sign-of-a-tiny-negative-rounding-to-zero
+    "0.00"
+    string
+      as-fixed -0.001 2
+
+  eq. ++> can-format-the-error-message-of-negative-places
+    "Can't write a fixed-point decimal with -2.000000 fraction places"
+    as-fixed
+      3.14159
+      -2
+      message > [message]
+
+  eq. ++> can-honour-custom-places
+    "3.14"
+    string
+      as-fixed 3.14159 2
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places
+    "3"
+    string
+      as-fixed 2.5 0
+
+  eq. ++> can-omit-the-decimal-point-with-zero-places-when-negative
+    "-3"
+    string
+      as-fixed -2.5 0
+
+  eq. ++> can-pad-with-trailing-zeros
+    "1.250000"
+    string
+      as-fixed 1.25 6
+
+  eq. ++> can-round-to-the-last-place
+    "0.123457"
+    string
+      as-fixed 0.123456789 6
+
+  eq. ++> can-write-a-negative-value
+    "-2.500000"
+    string
+      as-fixed -2.5 6
+
+  eq. ++> can-write-a-single-place
+    "2.5"
+    string
+      as-fixed 2.5 1
+
+  eq. ++> can-write-zero-with-places
+    "0.000000"
+    string
+      as-fixed 0 6
+
+  eq. ++> rejects-infinite-places
+    "recovered"
+    as-fixed
+      1.25
+      pinf
+      "recovered" > [message]
+
+  eq. ++> rejects-negative-places
+    "recovered"
+    as-fixed
+      3.14159
+      -2
+      "recovered" > [message]
+
+  eq. ++> rejects-non-integer-places
+    "recovered"
+    as-fixed
+      3.14159
+      2.5
+      "recovered" > [message]
+
+  as-fixed --> stops-on-negative-places
+    3.14159
+    -2

--- a/objects/string/as-hex.eo
+++ b/objects/string/as-hex.eo
@@ -1,0 +1,70 @@
+# Writes the bytes `b` as uppercase hexadecimal pairs joined by a hyphen,
+# so that the two bytes `0x4A 0x65` become `4A-65`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[b] > as-hex
+  if. > [h] >> hex-digit
+    h.lt 10
+    as-char
+      h.plus 48
+    as-char
+      h.plus 55
+  [index acc] >> rec-hex
+    if. > @
+      index.eq b.size
+      acc
+      rec-hex
+        as-number.
+          index.plus 1
+        if.
+          index.eq 0
+          pair
+          concat.
+            acc.concat "-".as-bytes
+            pair
+    as-ascii > bval
+      b.slice index 1
+    concat. > pair
+      hex-digit
+        floor.
+          bval.div 16
+      hex-digit
+        bval.minus
+          times.
+            floor.
+              bval.div 16
+            16
+  | > @
+    0
+    --
+
+  eq. ++> can-write-a-single-byte
+    "41"
+    string
+      as-hex "A".as-bytes
+
+  eq. ++> can-join-bytes-with-hyphens
+    "4A-65-66-66"
+    string
+      as-hex "Jeff".as-bytes
+
+  eq. ++> can-write-letter-nibbles
+    "00-00-00-00-00-00-00-FF"
+    string
+      as-hex 255.as-i64.as-bytes
+
+  eq. ++> can-write-the-bytes-of-a-number
+    "40-45-00-00-00-00-00-00"
+    string
+      as-hex 42.as-bytes
+
+  eq. ++> can-write-empty-bytes
+    ""
+    string
+      as-hex --

--- a/objects/string/as-number.eo
+++ b/objects/string/as-number.eo
@@ -1,0 +1,76 @@
+# Returns the original `text` as `number`.
+# If the text is not numeric, the `cant-parse` fallback is returned,
+# or the bottom object when unbound.
+# The whole `text` must be the number: `scanf` matches its `%f` pattern
+# unanchored (via `find`), so on its own it would accept any text that
+# merely contains a number-shaped substring, e.g. `"$100"` or `"12.34.56"`.
+# The text is therefore validated against the anchored equivalent of that
+# same `%f` token, so that only a text that is entirely a number is parsed.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text cant-parse] > as-number
+  if. > @
+    not.
+      matches.
+        compiled.
+          regex "/^[+-]?\\d+(?:\\.\\d+)?$/"
+        text
+    cant-parse
+      "Can't convert text %s to number".printf
+        * text
+    head.
+      ^.
+        at.
+          scanf "%f" text
+
+  eq. ++> can-convert-float-text
+    3.14
+    as-number "3.14"
+
+  eq. ++> can-convert-negative-text
+    -42
+    as-number "-42"
+
+  eq. ++> can-convert-text
+    5
+    as-number "5"
+
+  42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch
+
+  eq. ++> rejects-currency-prefixed-text
+    42
+    as-number
+      "$100"
+      42 > [message]
+
+  eq. ++> rejects-non-numeric-text
+    42
+    as-number
+      "Hello"
+      42 > [message]
+
+  eq. ++> rejects-space-separated-numbers
+    42
+    as-number
+      "1 2 3"
+      42 > [message]
+
+  eq. ++> rejects-text-with-an-embedded-number
+    42
+    as-number
+      "abc5"
+      42 > [message]
+
+  eq. ++> rejects-text-with-multiple-dots
+    42
+    as-number
+      "12.34.56"
+      42 > [message]
+
+  as-number "Hello" --> stops-on-converting-non-numeric-text

--- a/objects/string/at.eo
+++ b/objects/string/at.eo
@@ -1,0 +1,82 @@
+# Retrieve symbol by given index as `text`.
+# A negative `index` counts from the end of `text` (`length + index`).
+# If the resolved index is still negative or is >= `text.length`,
+# the `fallback` value is returned, or the bottom object when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text i fallback] > at
+  if. > @
+    or.
+      0.gt
+        if. >> index!
+          0.gt
+            i >> idx!
+          plus.
+            number len
+            idx
+          idx
+      or.
+        gte.
+          number index
+          text.length >> len!
+        not.
+          eq.
+            floor.
+              number index
+            number index
+    fallback
+      "Given index %d is out of text bounds".printf
+        * i
+    slice
+      text
+      index
+      1
+
+  eq. ++> can-return-a-character-at-a-negative-index
+    "m"
+    at
+      "some"
+      -2
+
+  eq. ++> can-return-the-first-character
+    "s"
+    at
+      "some"
+      0
+
+  eq. ++> can-return-the-third-character
+    "m"
+    at
+      "some"
+      2
+
+  eq. ++> rejects-a-fractional-index-in-bounds
+    "recovered"
+    at
+      "some"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> rejects-a-negative-fractional-index-in-bounds
+    "recovered"
+    at
+      "some"
+      -1.5
+      "recovered" > [message]
+
+  eq. ++> rejects-an-out-of-bounds-index
+    "recovered"
+    at
+      "some"
+      10
+      "recovered" > [message]
+
+  at --> stops-on-an-index-beyond-the-length
+    "some"
+    10

--- a/objects/string/chained.eo
+++ b/objects/string/chained.eo
@@ -1,0 +1,34 @@
+# Returns concatenation of `text` with all `other` strings.
+# Here `others` must be a `tuple` of `strings`.
+
++alias tuple.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text others] > chained
+  if. > @
+    0.eq others.length
+    text
+    string
+      tuple.reduced
+        others
+        text.as-bytes
+        accum.concat str.as-bytes > [accum str]
+
+  eq. ++> can-chain-with-other-strings
+    "Hello, world!"
+    chained *1
+      "Hello"
+      ", "
+      "world"
+      "!"
+
+  eq. ++> can-return-the-same-text-without-other-strings
+    "Some"
+    chained
+      "Some"
+      *

--- a/objects/string/contains-all.eo
+++ b/objects/string/contains-all.eo
@@ -1,0 +1,45 @@
+# Checks if `text` contains all elements from `substrings`.
+
++alias tuple.mapped
++alias tuple.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substrings] > contains-all
+  tuple.reduced > @
+    tuple.mapped
+      substrings
+      contains text x > [x] >>
+    true
+    x.and a > [a x]
+
+  contains-all ++> can-contain-all-of-no-substrings
+    "xyz"
+    *
+
+  contains-all ++> can-contain-all-of-no-substrings-when-empty
+    ""
+    *
+
+  contains-all *1 ++> can-contain-all-substrings
+    "abcdefghijk"
+    "abc"
+    "ghi"
+
+  contains-all *1 ++> can-contain-all-substrings-written-vertically
+    "Hello, world!"
+    "ell"
+    " "
+    ","
+    "d!"
+
+  not. ++> cannot-contain-all-substrings
+    contains-all *1
+      "qwerty"
+      "qer"
+      "ty"
+      "abc"

--- a/objects/string/contains-any.eo
+++ b/objects/string/contains-any.eo
@@ -1,0 +1,47 @@
+# Checks if `text` contains any element from `substrings`.
+
++alias tuple.mapped
++alias tuple.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substrings] > contains-any
+  tuple.reduced > @
+    tuple.mapped
+      substrings
+      contains text! x > [x] >>
+    false
+    x.or a > [a x]
+
+  contains-any *1 ++> can-contain-any-substring
+    "Good morning"
+    "oo"
+    "goo"
+
+  contains-any *1 ++> can-contain-any-substring-written-vertically
+    "foo bar buzz"
+    "bar"
+    " "
+    "o"
+
+  not. ++> cannot-contain-any-of-no-substrings
+    contains-any
+      "text"
+      *
+
+  not. ++> cannot-contain-any-of-no-substrings-when-empty
+    contains-any
+      ""
+      *
+
+  not. ++> cannot-contain-any-substring
+    contains-any *1
+      "xyzw"
+      "yx"
+      "zyx"
+      "wx"
+      "abc"

--- a/objects/string/contains.eo
+++ b/objects/string/contains.eo
@@ -1,0 +1,43 @@
+# Checks if `text` contains `substring`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substring] > contains
+  and. > @
+    gte.
+      number
+        txt.size >> length!
+      part.size >> size!
+    or.
+      and.
+        length.eq size
+        eq.
+          text >> txt!
+          substring >> part!
+      [index] >> rec-contains
+        if. > @
+          end.eq index
+          includes
+          includes.or
+            rec-contains (index.plus 1).as-number
+        eq. > includes
+          txt.slice index size
+          part
+      | 0
+  minus. >> end!
+    number length
+    size
+
+  contains ++> can-contain-a-substring
+    "Hello, world!"
+    "o, wo"
+
+  not. ++> cannot-contain-an-absent-substring
+    contains
+      "Hello, world!"
+      "Hey"

--- a/objects/string/ends-with.eo
+++ b/objects/string/ends-with.eo
@@ -1,0 +1,32 @@
+# Checks that `text` ends with `substring`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substring] > ends-with
+  and. > @
+    lte.
+      number
+        part.size >> size!
+      txt.size >> length!
+    eq.
+      slice.
+        text >> txt!
+        minus.
+          number length
+          size
+        size
+      substring >> part!
+
+  ends-with ++> can-end-with-a-substring
+    "Hello world!"
+    "world!"
+
+  not. ++> cannot-end-with-an-absent-substring
+    ends-with
+      "Hello world!"
+      "Hello"

--- a/objects/string/index-of.eo
+++ b/objects/string/index-of.eo
@@ -1,0 +1,80 @@
+# Returns index of `substring` in `text`.
+# If no `substring` was found, it returns -1.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substring] > index-of
+  if. > @
+    or.
+      or.
+        gt.
+          number
+            part.size >> size!
+          txt.size >> tlen!
+        and.
+          size.eq tlen
+          not.
+            eq.
+              substring >> part!
+              text >> txt!
+      found.eq -1
+    -1
+    length.
+      string
+        txt.slice
+          0
+          rec-index-of 0 >> found!
+  minus. >> end!
+    number tlen
+    size
+  [idx] >> rec-index-of
+    if. > @
+      end.eq idx
+      includes.if idx -1
+      includes.if
+        idx
+        rec-index-of (idx.plus 1).as-number
+    eq. > includes
+      txt.slice idx size
+      part
+
+  eq. ++> can-find-a-present-substring-in-utf-text
+    3
+    index-of
+      "привет, друг!"
+      "в"
+
+  eq. ++> can-return-the-index-of-a-substring
+    6
+    index-of
+      "Hello \n world"
+      "\n"
+
+  eq. ++> can-return-the-index-of-a-substring-at-the-end
+    6
+    index-of
+      "Hello world"
+      "world"
+
+  eq. ++> cannot-find-a-longer-substring
+    -1
+    index-of
+      "Hello"
+      "Somebody"
+
+  eq. ++> cannot-find-an-absent-substring-in-utf-text
+    -1
+    index-of
+      "привет, друг!"
+      "x"
+
+  eq. ++> cannot-find-an-absent-substring-of-the-same-length
+    -1
+    index-of
+      "Hello"
+      "world"

--- a/objects/string/is-alpha.eo
+++ b/objects/string/is-alpha.eo
@@ -1,0 +1,25 @@
+# Check that all signs in `text` are letters.
+# Works only for english letters.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > is-alpha
+  matches. > @
+    regex "/^[a-zA-Z]+$/"
+    text
+
+  is-alpha "eEo" ++> can-be-alphabetic-when-simple-text
+
+  not. ++> cannot-be-alphabetic-when-empty
+    is-alpha ""
+
+  not. ++> cannot-be-alphabetic-with-a-number
+    is-alpha "ab3d"
+
+  not. ++> cannot-be-alphabetic-with-dashes
+    is-alpha "-w-"

--- a/objects/string/is-alphanumeric.eo
+++ b/objects/string/is-alphanumeric.eo
@@ -1,0 +1,24 @@
+# Check that all signs in `text` are numbers or letters.
+# Works only for english letters.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > is-alphanumeric
+  matches. > @
+    regex "/^[A-Za-z0-9]+$/"
+    text
+
+  is-alphanumeric "eEo" ++> can-be-alphanumeric-when-simple-text
+
+  is-alphanumeric "ab3d" ++> can-be-alphanumeric-with-a-number
+
+  not. ++> cannot-be-alphanumeric-when-empty
+    is-alphanumeric ""
+
+  not. ++> cannot-be-alphanumeric-with-dashes
+    is-alphanumeric "-w-"

--- a/objects/string/is-ascii.eo
+++ b/objects/string/is-ascii.eo
@@ -1,0 +1,23 @@
+# Check that all signs in `text` are ASCII characters.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > is-ascii
+  matches. > @
+    regex "/^[\\x00-\\x7F]+$/"
+    text
+
+  is-ascii "123" ++> can-be-ascii-when-digits
+
+  is-ascii "H311oW" ++> can-be-ascii-when-plain-text
+
+  not. ++> cannot-be-ascii-when-empty
+    is-ascii ""
+
+  not. ++> cannot-be-ascii-with-an-emoji
+    is-ascii "🌵"

--- a/objects/string/is-digit.eo
+++ b/objects/string/is-digit.eo
@@ -1,0 +1,37 @@
+# Check that all signs in `text` are decimal digits.
+# Works only for english digits.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > is-digit
+  matches. > @
+    regex "/^[0-9]+$/"
+    text
+
+  is-digit "2026" ++> can-be-digits-when-a-number
+
+  is-digit "7" ++> can-be-digits-when-a-single-digit
+
+  is-digit ++> can-be-digits-when-a-very-long-number
+    "123456789012345678901234567890123456789012345678901234567890"
+
+  not. ++> cannot-be-digits-when-empty
+    is-digit ""
+
+  not. ++> cannot-be-digits-with-a-letter
+    is-digit "1a2"
+
+  not. ++> cannot-be-digits-with-a-space
+    is-digit
+      "12 34"
+
+  not. ++> cannot-be-digits-with-a-special-character
+    is-digit "1🌵2"
+
+  not. ++> cannot-be-digits-with-a-trailing-newline
+    is-digit "123\n"

--- a/objects/string/joined.eo
+++ b/objects/string/joined.eo
@@ -1,0 +1,46 @@
+# Joins `items`, which is a `tuple` of strings, using current `text`
+# as a delimiter.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text items] > joined
+  string > @
+    if. >>!
+      items.length.eq 0
+      --
+      [acc tup] >> with-delimiter
+        if. > @
+          tup.length.eq 0
+          acc
+          with-delimiter
+            concat.
+              concat. (dataized tup.head) text!
+              acc
+            tup.tail
+      | items.head items.tail
+
+  eq. ++> can-join-many-strings
+    "hello-world-dear-friend"
+    joined *1
+      "-"
+      "hello"
+      "world"
+      "dear"
+      "friend"
+
+  eq. ++> can-join-no-strings
+    ""
+    joined
+      "-"
+      *
+
+  eq. ++> can-join-one-string
+    "some"
+    joined *1
+      "-"
+      "some"

--- a/objects/string/last-index-of.eo
+++ b/objects/string/last-index-of.eo
@@ -1,0 +1,74 @@
+# Returns last index of `substring` in `text`.
+# If no element was found, it returns -1.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substring] > last-index-of
+  if. > @
+    or.
+      or.
+        gt.
+          number
+            part.size >> size!
+          txt.size >> tlen!
+        and.
+          size.eq tlen
+          not.
+            eq.
+              substring >> part!
+              text >> txt!
+      found.eq -1
+    -1
+    length.
+      string
+        txt.slice
+          0
+          rec-index-of >> found!
+            minus.
+              number tlen
+              size
+  [idx] >> rec-index-of
+    if. > @
+      0.eq idx
+      includes.if idx -1
+      includes.if
+        idx
+        rec-index-of (idx.plus -1).as-number
+    eq. > includes
+      txt.slice idx size
+      part
+
+  eq. ++> can-find-the-last-index-of-a-substring
+    5
+    last-index-of
+      "Hey, Hey, Hey"
+      "Hey,"
+
+  eq. ++> can-find-the-last-index-of-a-substring-in-utf-text
+    3
+    last-index-of
+      "привет, друг!"
+      "в"
+
+  eq. ++> can-find-the-last-index-of-the-whole-string
+    0
+    last-index-of
+      "Hello"
+      "Hello"
+
+  eq. ++> cannot-find-the-last-index-of-an-absent-substring
+    -1
+    last-index-of
+      "Hello, world"
+      "somebody"
+
+  eq. ++> cannot-find-the-last-index-of-an-absent-substring-in-utf-text
+    -1
+    last-index-of
+      "привет, друг!"
+      "x"

--- a/objects/string/length.eo
+++ b/objects/string/length.eo
@@ -1,0 +1,90 @@
+# Counts the characters in the `text`, and not its bytes. The UTF-8 sequence
+# is walked character by character, so a multi-byte character counts as one.
+# A sequence that does not end with a complete character terminates
+# the computation.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > length
+  if. > @
+    eq.
+      text.as-bytes.size >> size!
+      0
+    0
+    [index accum] >> reclen
+      if. > @
+        index.eq size
+        accum
+        if.
+          eq.
+            byte.and 80-
+            00-
+          inclen index 1 accum
+          if.
+            eq.
+              byte.and E0-
+              C0-
+            inclen index 2 accum
+            if.
+              eq.
+                byte.and F0-
+                E0-
+              inclen index 3 accum
+              if.
+                eq.
+                  byte.and F8-
+                  F0-
+                inclen index 4 accum
+                T
+                  "Unknown byte format (%x), can't recognize character".printf
+                    * byte
+      text.as-bytes.slice index 1 > byte
+    | 0 0
+  if. > [index csize len] >> inclen
+    gt.
+      index.plus csize
+      size
+    T
+      "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
+        *
+          csize
+          index
+          text.as-bytes
+    reclen
+      index.plus csize
+      len.plus 1
+
+  eq. ++> can-count-a-text-of-spaces-only
+    " ".length
+    1
+
+  ++> can-count-four-byte-characters
+    and. > @
+      str.length.eq 11
+      str.as-bytes.size.eq 14
+    "The 😀 smile" > str
+
+  eq. ++> can-count-the-characters-of-the-origin-text
+    length
+      "Hello, world!"
+    13
+
+  ++> can-count-three-byte-characters
+    and. > @
+      str.length.eq 16
+      str.as-bytes.size.eq 18
+    "The अ devanagari" > str
+
+  ++> can-count-two-byte-characters
+    and. > @
+      str.length.eq 12
+      str.as-bytes.size.eq 16
+    "Hello, друг!" > str
+
+  length --> stops-on-an-incomplete-four-byte-character
+    string F0-9F-98

--- a/objects/string/low-cased.eo
+++ b/objects/string/low-cased.eo
@@ -1,0 +1,42 @@
+# Returns the `text` in lower case.
+
++alias tuple.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > low-cased
+  string > @
+    tuple.reduced
+      text.as-bytes.array
+      --
+      [accum byte] >>
+        accum.concat > @
+          if.
+            and.
+              code.lte
+                as-ascii "Z"
+              code.gte
+                as-ascii "A"
+            slice.
+              as-bytes.
+                as-i64.
+                  code.plus
+                    minus.
+                      as-ascii "a"
+                      as-ascii "A"
+              7
+              1
+            byte
+        as-ascii byte > code
+
+  eq. ++> can-convert-already-lower-cased-text
+    "hello"
+    low-cased "HeLlO"
+
+  eq. ++> can-convert-text-to-lower-case
+    "hello"
+    low-cased "HELLO"

--- a/objects/string/nsplit.eo
+++ b/objects/string/nsplit.eo
@@ -1,0 +1,173 @@
+# Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
+# The last element contains the remainder of the string after splitting.
+# If `limit` is not a finite integer of at least 1 (fractional, nan, infinite,
+# zero or negative), the `cant-split` fallback is returned, or the bottom object when unbound.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text delimiter limit cant-split] > nsplit
+  if. > @
+    or.
+      1.gt limit
+      limit.is-integer.not
+    cant-split
+      "Invalid limit %d for nsplit, must be at least 1".printf
+        * limit
+    if.
+      text.size.eq 0
+      *
+      if.
+        1.eq limit
+        * text
+        [accum start current count] >> rec-nsplit
+          if. > @
+            text.size.eq current
+            appended
+            if.
+              or.
+                size.eq 0
+                gt.
+                  current.plus size
+                  text.size
+              rec-nsplit
+                accum
+                start
+                as-number.
+                  current.plus 1
+                count
+              if.
+                and.
+                  delimiter.eq
+                    bts.slice current size
+                  lt.
+                    number count
+                    minus. (number limit) 1
+                rec-nsplit
+                  appended
+                  as-number.
+                    current.plus size
+                  as-number.
+                    current.plus size
+                  as-number.
+                    count.plus 1
+                rec-nsplit
+                  accum
+                  start
+                  as-number.
+                    current.plus 1
+                  count
+          accum.with > appended
+            string
+              bts.slice
+                start
+                current.minus start
+        |
+          *
+          0
+          0
+          0
+  text.as-bytes >> bts!
+  delimiter.size >> size!
+
+  eq. ++> can-split-into-empty-strings
+    nsplit
+      "-a-b-c"
+      "-"
+      3
+    *
+      ""
+      "a"
+      "b-c"
+
+  eq. ++> can-split-multi-byte-characters
+    nsplit
+      "аХбХв"
+      "Х"
+      3
+    *
+      "а"
+      "б"
+      "в"
+
+  eq. ++> can-split-on-a-multi-character-delimiter
+    nsplit
+      "a::b::c::d"
+      "::"
+      2
+    *
+      "a"
+      "b::c::d"
+
+  eq. ++> can-split-on-dashes-with-a-limit-of-two
+    nsplit
+      "a-b-c-d"
+      "-"
+      2
+    *
+      "a"
+      "b-c-d"
+
+  eq. ++> can-split-with-a-high-limit
+    nsplit
+      "a-b-c"
+      "-"
+      10
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> can-split-with-a-limit-of-one
+    nsplit
+      "a-b-c"
+      "-"
+      1
+    * "a-b-c"
+
+  eq. ++> can-split-with-a-limit-of-two
+    nsplit
+      "Cookie: a=1; b=2"
+      " "
+      2
+    *
+      "Cookie:"
+      "a=1; b=2"
+
+  eq. ++> rejects-a-fractional-limit
+    "recovered"
+    nsplit
+      "a-b-c"
+      "-"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> rejects-an-infinite-limit
+    "recovered"
+    nsplit
+      "a-b-c"
+      "-"
+      pinf
+      "recovered" > [message]
+
+  eq. ++> rejects-an-invalid-limit
+    "fallback"
+    nsplit
+      "text"
+      "-"
+      0
+      "fallback" > [message]
+
+  nsplit --> stops-on-a-limit-of-zero
+    "text"
+    "-"
+    0
+
+  nsplit --> stops-on-a-negative-limit
+    "text"
+    "-"
+    -1

--- a/objects/string/printf.eo
+++ b/objects/string/printf.eo
@@ -1,0 +1,234 @@
+# Object `printf` allows you to format and output text depending
+# on the arguments passed to it and return it as `org.eolang.string`.
+#
+# When arguments are processed - they're dataized and converted to objects
+# depending on next flags:
+# - %s - converts object to `string`
+# - %d - converts object to `int`
+# - %f - converts object to `float`
+# - %x - converts object to `bytes`
+# - %b - converts object to boolean, `true` or `false`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[] > printf /Q.string
+  ? > format /Q.string
+  ? > args /Q.tuple
+
+  eq. ++> can-apply-a-precision-to-bytes
+    "40-"
+    printf *1
+      "%.3x"
+      42.as-bytes
+
+  eq. ++> can-apply-a-width-to-bytes
+    "  40-45-00-00-00-00-00-00"
+    printf *1
+      "%25x"
+      42.as-bytes
+
+  eq. ++> can-format-a-float-with-six-fraction-digits
+    "1.250000"
+    printf *1
+      "%f"
+      1.25
+
+  eq. ++> can-format-a-numbered-substitution
+    "Hello, Jeff! Bye, Jeff!"
+    printf *1
+      "Hello, %s! Bye, %1$s!"
+      "Jeff"
+
+  eq. ++> can-format-a-numbered-substitution-with-many-arguments
+    "This is the first; This is the first as well; The second; and the 3"
+    printf *1
+      "This is the %s; This is the %1$s as well; The %s; and the %d"
+      "first"
+      "second"
+      3
+
+  eq. ++> can-format-a-precision-of-two-decimals
+    "3.14"
+    printf *1
+      "%.2f"
+      3.1415
+
+  eq. ++> can-format-a-width-with-leading-spaces
+    "   42"
+    printf *1
+      "%5d"
+      42
+
+  eq. ++> can-format-a-zero-float-with-six-fraction-digits
+    "0.000000"
+    printf *1
+      "%f"
+      0
+
+  eq. ++> can-format-left-justified-with-trailing-spaces
+    "x         "
+    printf *1
+      "%-10s"
+      "x"
+
+  eq. ++> can-format-objects-of-every-type
+    "string Jeff, bytes 4A-65-66-66, float 42.300000, int 14, bool false"
+    printf *1
+      "string %s, bytes %x, float %f, int %d, bool %b"
+      "Jeff"
+      "Jeff".as-bytes
+      42.3
+      14
+      false
+
+  eq. ++> can-format-ordered-numbered-substitutions
+    "first second second is after first"
+    printf *1
+      "%s %s %2$s is after %1$s"
+      "first"
+      "second"
+
+  eq. ++> can-ignore-extra-arguments
+    "Hey"
+    printf *1
+      "%s"
+      "Hey"
+      "Jeff"
+
+  eq. ++> can-left-align-bytes
+    "40-45-00-00-00-00-00-00  "
+    printf *1
+      "%-25x"
+      42.as-bytes
+
+  eq. ++> can-preserve-an-escaped-bytes-format
+    "%x"
+    printf
+      "%%x"
+      *
+
+  eq. ++> can-print-a-complex-string
+    "Привет 3.140000 Jeff X!"
+    printf *1
+      "Привет %f %s %s!"
+      3.14
+      "Jeff"
+      "X"
+
+  eq. ++> can-print-a-percent-sign
+    "%Jeff"
+    printf *1
+      "%%%s"
+      "Jeff"
+
+  eq. ++> can-print-a-simple-string
+    "Hello, Jeffrey!"
+    printf *1
+      "Hello, %s!"
+      "Jeffrey"
+
+  eq. ++> can-print-an-i64-as-a-number
+    "42"
+    printf *1
+      "%d"
+      42.as-i64.as-number
+
+  eq. ++> can-print-bytes
+    "40-45-00-00-00-00-00-00"
+    printf *1
+      "%x"
+      42.as-bytes
+
+  eq. ++> can-round-a-float-carrying-into-the-integer-part
+    "1.000000"
+    printf *1
+      "%f"
+      0.9999999
+
+  eq. ++> can-truncate-a-negative-float-toward-zero
+    "-7"
+    printf *1
+      "%d"
+      -7.89
+
+  eq. ++> can-truncate-a-positive-float-toward-zero
+    "42"
+    printf *1
+      "%d"
+      42.321
+
+  eq. ++> can-truncate-rather-than-round-a-float
+    "9"
+    printf *1
+      "%d"
+      9.99
+
+  not. ++> cannot-print-an-i64
+    eq.
+      printf *1
+        "%d"
+        42.as-i64
+      "42"
+
+  printf *1 --> stops-on-a-comma-flag-with-s
+    "%,s"
+    "Jeff"
+
+  printf *1 --> stops-on-a-comma-flag-with-x
+    "%,x"
+    5
+
+  printf *1 --> stops-on-a-hash-flag-with-s
+    "%#s"
+    "Jeff"
+
+  printf *1 --> stops-on-a-hash-flag-with-x
+    "%#x"
+    5
+
+  printf *1 --> stops-on-a-non-utf8-byte-argument-as-a-string
+    "%s"
+    3.14
+
+  printf *1 --> stops-on-a-paren-flag-with-s
+    "%(s"
+    "Jeff"
+
+  printf *1 --> stops-on-a-precision-with-d
+    "%.2d"
+    5
+
+  printf *1 --> stops-on-a-zero-flag-with-x
+    "%0x"
+    5
+
+  printf *1 --> stops-on-a-zero-positional-index
+    "%0$s"
+    "first"
+
+  printf *1 --> stops-on-an-oversized-positional-index
+    "%99999999999999999999$s"
+    "Jeff"
+
+  printf --> stops-on-an-unsupported-format
+    "%o"
+    *
+
+  printf *1 --> stops-on-arguments-that-do-not-match
+    "%s%s"
+    "Jeff"
+
+  printf *1 --> stops-on-formatting-a-huge-number-as-a-decimal
+    "%d"
+    1.0e30
+
+  printf *1 --> stops-on-formatting-nan-as-a-decimal
+    "%d"
+    nan

--- a/objects/string/regex.eo
+++ b/objects/string/regex.eo
@@ -1,0 +1,251 @@
+# Regular expression in Perl format.
+# Here `expression` is a string pattern.
+# It starts and ends with slash (e.g. "/(your-expression)/"),
+# Also it can be specified by the flag option,
+# e.g.
+# ```
+# (`Q.string.regex "/(word)/i").compiled.matches "WORD"
+# ```
+# Supported flags:
+# /d - Enables Unix lines mode.
+# /i - Enables case-insensitive matching.
+# /x - Permits whitespace and comments in pattern.
+# /m - Enables multiline mode.
+# /s - Enables dotall mode.
+# /u - Enables Unicode-aware case folding.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
+
+[expression] > regex
+  compile > @
+  [] > compile /Q.string.regex.pattern
+    ? > cant-compile /{Q.string}
+  [serialized] > pattern
+    pattern serialized > compiled
+    [txt] > match
+      [position start from to groups] > matched
+        groups.length > count
+        start.gte 0 > exists
+        groups.at index > [index] > group
+        $ > matched
+        exists.if > next
+          matched.
+            matched-from-index
+              position.plus 1
+              to
+          T
+            "Matched block does not exist, can't get next"
+        exists.if > text
+          group 0
+          T
+            "Matched block does not exist, can't get text"
+      [] > matched-from-index /Q.string.regex.pattern.match.matched
+        ? > position /Q.number
+        ? > start /Q.number
+      matched. > next
+        matched-from-index 1 0
+    [txt] > matches
+      found.exists.and > @
+        and.
+          found.to.eq txt.length
+          found.from.eq 0
+      next. > found
+        match txt
+
+  ++> can-expose-groups-on-each-matched-block
+    and. > @
+      and.
+        and.
+          first.count.eq 3
+          eq.
+            first.group 1
+            "hello"
+        eq.
+          first.group 2
+          "1"
+      and.
+        and.
+          second.count.eq 3
+          eq.
+            second.group 1
+            "world"
+        eq.
+          second.group 2
+          "2"
+    next. > first
+      match.
+        compiled.
+          regex "/([a-z]+)([1-9]{1})/"
+        "!hello1!world2"
+    first.next > second
+
+  matches. ++> can-ignore-comments-in-a-pattern
+    compiled.
+      regex
+        "/(\\d) #ignore this comment/x"
+    "4"
+
+  matches. ++> can-match-a-text-against-a-pattern
+    compiled.
+      regex "/[a-z]+/"
+    "hello"
+
+  matches. ++> can-match-an-entire-pattern
+    compiled.
+      regex "/[0-9]/\\d+/"
+    "2/75"
+
+  matches. ++> can-match-with-the-case-insensitive-option
+    compiled.
+      regex "/(string)/i"
+    "StRiNg"
+
+  matches. ++> can-match-with-the-case-insensitive-option-and-capitals
+    compiled.
+      regex "/(word)/i"
+    "WORD"
+
+  matches. ++> can-match-with-the-dotall-option
+    compiled.
+      regex "/(.*)/s"
+    "too \\n many \\n line \\n Feed\\n"
+
+  matches. ++> can-match-with-the-multiline-option
+    compiled.
+      regex "/(^([0-9]+).*)/m"
+    "1 bottle of water on the wall. \\n1 bottle of water."
+
+  matches. ++> can-match-with-the-unicode-case-option
+    compiled.
+      regex "/(yildirim)/ui"
+    "Yıldırım"
+
+  matches. ++> can-match-with-the-unix-lines-option
+    compiled.
+      regex "/(.+)/d"
+    "A\\r\\nB\\rC\\nD"
+
+  ++> can-report-the-border-indexes-of-a-match
+    and. > @
+      0.eq n.start
+      and.
+        1.eq n.from
+        6.eq n.to
+    next. > n
+      match.
+        regex "/[a-z]+/"
+        "!hello!"
+
+  eq. ++> can-return-the-matched-string-sequence
+    text.
+      next.
+        match.
+          regex "/[a-z]+/"
+          "!hello!"
+    "hello"
+
+  ++> can-return-the-second-matched-block
+    and. > @
+      and.
+        and.
+          and.
+            second.text.eq "world"
+            second.position.eq 2
+          second.start.eq 6
+        second.from.eq 7
+      second.to.eq 12
+    next. > second
+      next.
+        match.
+          regex "/[a-z]+/"
+          "!hello!world!"
+
+  not. ++> cannot-match-a-text-against-a-wrong-pattern
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "123"
+
+  not. ++> cannot-match-an-anchored-pattern-with-a-trailing-newline
+    matches.
+      compiled.
+        regex "/^[0-9]+$/"
+      "123\n"
+
+  not. ++> cannot-match-with-unmatched-leading-characters
+    matches.
+      compiled.
+        regex "/[a-z]+/"
+      "1abc"
+
+  eq. ++> rejects-a-pattern-with-a-missing-slash
+    "no-slash"
+    compile.
+      regex "(.)+"
+      "no-slash" > [message]
+
+  eq. ++> rejects-invalid-regex-syntax
+    "recovered"
+    compile.
+      regex "/[a-z/"
+      "recovered" > [message]
+
+  compiled. --> stops-on-a-missing-closing-slash
+    regex "/pattern"
+
+  compiled. --> stops-on-a-missing-first-slash
+    regex "(.)+"
+
+  compile. --> stops-on-compiling-an-invalid-pattern
+    regex "/[a-z/"
+
+  group. --> stops-on-taking-a-group-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+    1
+
+  to. --> stops-on-taking-the-end-position-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  count. --> stops-on-taking-the-group-count-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  groups. --> stops-on-taking-the-groups-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  next. --> stops-on-taking-the-next-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  from. --> stops-on-taking-the-start-position-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"
+
+  text. --> stops-on-taking-the-text-of-an-unmatched-block
+    next.
+      match.
+        regex "/[a-z]+/"
+        "123"

--- a/objects/string/repeated.eo
+++ b/objects/string/repeated.eo
@@ -1,0 +1,80 @@
+# Returns `text` repeated `times` times.
+# If `times` is not a finite non-negative integer (negative, fractional, nan
+# or infinite), the `cant-repeat` fallback is returned,
+# or the bottom object when unbound.
+# If `times` == 0, empty text is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text times cant-repeat] > repeated
+  if. > @
+    or.
+      0.gt times
+      times.is-integer.not
+    cant-repeat
+      "Can't repeat text %f times".printf
+        * times
+    string
+      if. >> result!
+        0.eq
+          times >> amount!
+        --
+        if. > [accum index] >> rec-repeated
+          amount.eq index
+          accum
+          rec-repeated
+            accum.concat b
+            as-number.
+              index.plus 1
+        |
+          text >> b!
+          1
+
+  eq. ++> can-format-the-error-message-of-a-negative-count
+    "Can't repeat text -1.000000 times"
+    repeated
+      "x"
+      -1
+      message > [message]
+
+  eq. ++> can-repeat-a-text-five-times
+    "heyheyheyheyhey"
+    repeated
+      "hey"
+      5
+
+  eq. ++> can-repeat-a-text-zero-times
+    ""
+    repeated
+      "some"
+      0
+
+  eq. ++> rejects-a-negative-count
+    "recovered"
+    repeated
+      "x"
+      -1
+      "recovered" > [message]
+
+  eq. ++> rejects-a-non-integer-count
+    "recovered"
+    repeated
+      "x"
+      2.5
+      "recovered" > [message]
+
+  eq. ++> rejects-an-infinite-count
+    "recovered"
+    repeated
+      "x"
+      pinf
+      "recovered" > [message]
+
+  repeated --> stops-on-a-negative-count
+    ""
+    -1

--- a/objects/string/replaced.eo
+++ b/objects/string/replaced.eo
@@ -1,0 +1,71 @@
+# Returns `text` where all regex target changed to replacement.
+# Here `target` must be a `org.eolang.string.regex` object.
+# The `replacement` here is a `string` that would be pasted instead of
+# matched text in original one.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text target replacement] > replaced
+  matched.exists.not.if > @
+    string text! >> reinit
+    block.exists.if > [block accum start] >> rec-replaced
+      rec-replaced
+        block.next
+        concat.
+          accum.concat
+            reinit.slice
+              start
+              block.from.minus start
+          replacement
+        block.to
+      string
+        accum.concat
+          reinit.slice
+            start
+            reinit.length.minus start
+    |
+      matched
+      ""
+      start.
+        next. >> matched
+          target.match reinit
+
+  eq. ++> can-replace-a-windows-separator-with-a-slash
+    replaced
+      "C:\\Windows\\Users\\AppLocal\\shrek"
+      regex "/[\\\\:]+/"
+      "/"
+    "C/Windows/Users/AppLocal/shrek"
+
+  eq. ++> can-replace-digits-with-a-string
+    replaced
+      "Hell0, w0rld"
+      regex "/[0-9]+/"
+      "o"
+    "Hello, world"
+
+  eq. ++> can-replace-slashes-with-a-windows-separator
+    replaced
+      "C:\\Windows/foo\\bar/hello.txt"
+      regex "/\\//"
+      "\\"
+    "C:\\Windows\\foo\\bar\\hello.txt"
+
+  eq. ++> can-sanitize-a-windows-path
+    replaced
+      "foo\\bar<:>?*\"|baz\\asdf"
+      regex "/[<>:\\\"\\/\\|\\?\\*\\x00-\\x1F]/"
+      ""
+    "foo\\barbaz\\asdf"
+
+  eq. ++> cannot-replace-when-the-pattern-is-absent
+    replaced
+      "Hello, world"
+      regex "/[0-9]+/"
+      "12345"
+    "Hello, world"

--- a/objects/string/scanf.eo
+++ b/objects/string/scanf.eo
@@ -1,0 +1,403 @@
+# Reads formatted input from a string.
+# This object has two free attributes:
+# 1. `format` - is a formatter string (e.g. "Hello, %s!")
+# 2. `read` - is a string where data exists (e.g. "Hello, John!")
+# returns a `org.eolang.tuple` of formatted values (e.g. * "John").
+# Supported formatters are:
+# - %d - parse as integer and convert to `number`
+# - %f - parse as float and convert to `number`
+# - %s - parse as string and convert to `string`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[format read] > scanf
+  [pattern specifiers] >>
+    [text] > as-float
+      negative.if negated magnitude > @
+      index-of unsigned "." > dot
+      if. > magnitude
+        not.
+          dot.eq -1
+        plus.
+          fold-digits
+            slice unsigned 0 dot
+          div.
+            fold-digits
+              slice
+                unsigned
+                dot.plus 1
+                places
+            10.power places
+        fold-digits unsigned
+      magnitude.times -1 > negated
+      eq. > negative
+        slice
+          text
+          0
+          1
+        "-"
+      unsigned.length.minus > places
+        dot.plus 1
+      negative.or > signed
+        eq.
+          slice text 0 1
+          "+"
+      signed.if > unsigned
+        slice
+          text
+          1
+          text.length.minus 1
+        text
+    [text] > as-integer
+      if. > @
+        or.
+          normalized.length.gt 19
+          and.
+            normalized.length.eq 19
+            not.
+              negative.if
+                digits-lte normalized "9223372036854775808"
+                digits-lte normalized "9223372036854775807"
+        T
+          "The number doesn't fit into long range for the '%%d' conversion"
+        negative.if negated folded
+      [a b] > digits-lte
+        if. > [index] >> rec
+          index.eq a.length
+          true
+          if.
+            lt.
+              as-ascii
+                slice a index 1
+              as-ascii
+                slice b index 1
+            true
+            if.
+              gt.
+                as-ascii
+                  slice a index 1
+                as-ascii
+                  slice b index 1
+              false
+              rec
+                index.plus 1
+        | 0 > @
+      fold-digits normalized > folded
+      folded.times -1 > negated
+      eq. > negative
+        slice
+          text
+          0
+          1
+        "-"
+      if. > normalized
+        stripped.eq ""
+        "0"
+        stripped
+      negative.or > signed
+        eq.
+          slice text 0 1
+          "+"
+      replaced > stripped
+        signed.if
+          slice
+            text
+            1
+            text.length.minus 1
+          text
+        regex "/^0+/"
+        ""
+    [group acc] >> convert
+      matched.exists.not.if > @
+        *
+        if.
+          group.gt specifiers.length
+          acc
+          next
+      convert > next
+        group.plus 1
+        acc.with
+          converted
+            specifiers.at
+              group.minus 1
+              T
+            matched.group group
+    | > @
+      1
+      *
+    if. > [spec text] > converted
+      spec.eq "s"
+      text
+      if.
+        spec.eq "d"
+        as-integer text
+        as-float text
+    [text] > fold-digits
+      [index acc] >> rec
+        if. > @
+          index.eq text.length
+          acc
+          next
+        rec > next
+          index.plus 1
+          plus.
+            acc.times 10
+            minus.
+              as-ascii
+                slice text index 1
+              48
+      | 0 0 > @
+    match. > found
+      regex
+        chained *1
+          "/"
+          "^"
+          pattern
+          "/"
+      read
+    found.next > matched
+  | > @
+    tokens.at
+      0
+      T
+    tokens.at
+      1
+      T
+  if. > [ch] >> escaped
+    contains.
+      *
+        "\\"
+        "^"
+        "$"
+        "."
+        "|"
+        "?"
+        "*"
+        "+"
+        "("
+        ")"
+        "["
+        "]"
+        "{"
+        "}"
+        "/"
+      ch
+    chained *1
+      "\\"
+      ch
+    ch
+  [position accumulated found pending] >> tokenize
+    if. > @
+      position.gte format.length
+      pending.if *1
+        T
+          "The format string ends with a dangling percent and no specifier after it"
+        accumulated
+        found
+      pending.if
+        if.
+          ch.eq "%"
+          tokenize
+            position.plus 1
+            chained *1
+              accumulated
+              "%"
+            found
+            false
+          if.
+            ch.eq "d"
+            tokenize
+              position.plus 1
+              chained *1
+                accumulated
+                "([+-]?\\d+)"
+              found.with "d"
+              false
+            if.
+              ch.eq "f"
+              tokenize
+                position.plus 1
+                chained *1
+                  accumulated
+                  "([+-]?\\d+(?:\\.\\d+)?)"
+                found.with "f"
+                false
+              if.
+                ch.eq "s"
+                tokenize
+                  position.plus 1
+                  chained *1
+                    accumulated
+                    "(\\S+)"
+                  found.with "s"
+                  false
+                T "Unsupported format specifier"
+        if.
+          ch.eq "%"
+          tokenize
+            position.plus 1
+            accumulated
+            found
+            true
+          tokenize
+            position.plus 1
+            chained *1
+              accumulated
+              escaped ch
+            found
+            false
+    slice > ch
+      format
+      position
+      1
+  | >> tokens
+    0
+    ""
+    *
+    false
+
+  eq. ++> can-scan-a-complex-format
+    scanf
+      "Im%d %s old and this is! Let's calculate %f + %f= %f"
+      "Im18 years old and this is! Let's calculate 99999999.99 + 0.01= 100000000.0"
+    *
+      18
+      "years"
+      9.999999999E7
+      0.01
+      100000000
+
+  eq. ++> can-scan-a-complex-float
+    1991.01
+    head.
+      scanf
+        "this will be=%f"
+        "this will be=1991.01"
+
+  eq. ++> can-scan-a-complex-integer
+    734987259
+    head.
+      scanf "!%d!" "!734987259!"
+
+  eq. ++> can-scan-a-complex-string
+    "test"
+    head.
+      scanf "some%sstring" "someteststring"
+
+  eq. ++> can-scan-a-float
+    0.24
+    head.
+      scanf "%f" "0.24"
+
+  eq. ++> can-scan-an-integer
+    33
+    head.
+      scanf "%d" "33"
+
+  eq. ++> can-scan-a-negative-integer
+    -42
+    head.
+      scanf "%d" "-42"
+
+  eq. ++> can-scan-a-positive-signed-integer
+    42
+    head.
+      scanf "%d" "+42"
+
+  eq. ++> can-scan-a-zero-padded-integer
+    42
+    head.
+      scanf "%d" "00000000000000000042"
+
+  eq. ++> can-scan-a-zero-padded-negative-integer
+    -42
+    head.
+      scanf "%d" "-00000000000000000042"
+
+  eq. ++> can-scan-many-zeroes-as-zero
+    0
+    head.
+      scanf "%d" "00000000000000000000"
+
+  eq. ++> can-scan-what-printf-wrote
+    scanf
+      "%s is about %d?"
+      printf *1
+        "%s is about %d?"
+        "This"
+        8
+    *
+      "This"
+      8
+
+  eq. ++> can-scan-a-string
+    "hello"
+    head.
+      scanf "%s" "hello"
+
+  eq. ++> can-scan-a-string-an-integer-and-a-float
+    scanf
+      "%s %d %f"
+      "hello 33 0.24"
+    *
+      "hello"
+      33
+      0.24
+
+  eq. ++> can-scan-a-string-followed-by-a-literal
+    "hello"
+    head.
+      scanf "%s!" "hello!"
+
+  eq. ++> can-scan-while-ignoring-trailing-text
+    42
+    head.
+      scanf
+        "id=%d"
+        "id=42 suffix"
+
+  eq. ++> cannot-scan-past-unmatched-leading-text
+    length.
+      scanf
+        "id=%d"
+        "prefix id=42"
+    0
+
+  scanf --> stops-on-a-dangling-percent
+    "hello%"
+    "hello"
+
+  scanf --> stops-on-an-oversized-integer
+    "%d"
+    "99999999999999999999"
+
+  gt. ++> can-scan-a-nineteen-digit-value-at-long-max
+    head.
+      scanf "%d" "9223372036854775807"
+    9000000000000000000
+
+  lt. ++> can-scan-a-nineteen-digit-value-at-long-min
+    head.
+      scanf "%d" "-9223372036854775808"
+    -9000000000000000000
+
+  scanf --> stops-on-a-nineteen-digit-value-above-long-max
+    "%d"
+    "9223372036854775808"
+
+  scanf --> stops-on-a-nineteen-digit-value-below-long-min
+    "%d"
+    "-9223372036854775809"
+
+  scanf --> stops-on-a-zero-padded-integer-above-long-max
+    "%d"
+    "00009223372036854775808"
+
+  scanf --> stops-on-a-wrong-format
+    "%l"
+    "error"

--- a/objects/string/slice.eo
+++ b/objects/string/slice.eo
@@ -1,0 +1,206 @@
+# Takes a piece of the `text` as another `text`, counting characters and not
+# bytes. Here `start` must be a non-negative index to start slicing from, while
+# `len` must be a non-negative amount of characters to take. Both of them walk
+# the UTF-8 sequence character by character, so a multi-byte character counts
+# as one. An index outside the bounds of the `text` terminates the computation.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
+
+[text start len] > slice
+  if. > @
+    nstart.lt 0
+    T
+      "Start index must be >= 0, but was %d".printf
+        * nstart
+    if.
+      nlen.lt 0
+      T
+        "Length to slice must be >= 0, but was %d".printf
+          * nlen
+      seq *
+        recidx >> bstart!
+          0
+          0
+          nstart
+          "Start index (%d) is out of string bounds".printf
+            * nstart
+        blen
+        if.
+          nlen.eq 0
+          ""
+          string
+            text.as-bytes.slice bstart blen
+  minus. > blen
+    [index accum result cause] >> recidx
+      if. > @
+        accum.eq result
+        index
+        if.
+          index.eq size
+          T cause
+          if.
+            eq.
+              byte.and p1
+              r1
+            increase
+              index
+              1
+              accum
+              result
+              cause
+            if.
+              eq.
+                byte.and p2
+                r2
+              increase
+                index
+                2
+                accum
+                result
+                cause
+              if.
+                eq.
+                  byte.and p3
+                  r3
+                increase index 3 accum result cause
+                if.
+                  eq. (byte.and p4) r4
+                  increase index 4 accum result cause
+                  T
+                    "Unknown byte format (%x), can't recognize character".printf
+                      * byte
+      text.as-bytes.slice index 1 > byte
+    |
+      number bstart
+      0
+      nlen
+      "Start index + length to slice (%d) is out of string bounds".printf
+        *
+          nstart.plus nlen
+    bstart
+  if. > [index csize accum result cause] > increase
+    gt.
+      index.plus csize
+      size
+    T
+      "Expected %d byte character at %d index, but there are not enough bytes for it: %x".printf
+        *
+          csize
+          index
+          text.as-bytes
+    recidx
+      index.plus csize
+      accum.plus 1
+      result
+      cause
+  number len! > nlen
+  number start! > nstart
+  80- > p1
+  E0- > p2
+  F0- > p3
+  F8- > p4
+  00- > r1
+  C0- > r2
+  E0- > r3
+  F0- > r4
+  text.as-bytes.size >> size!
+
+  eq. ++> can-slice-a-line-break-escape-sequence
+    "\n".slice
+      0
+      "\n".length
+    "\n"
+
+  eq. ++> can-slice-a-unicode-escape-sequence
+    "Ф".slice
+      0
+      "Ф".length
+    "Ф"
+
+  eq. ++> can-slice-an-empty-string
+    "".slice
+      0
+      0
+    ""
+
+  eq. ++> can-slice-at-the-end-with-a-zero-length
+    "hello".slice
+      5
+      0
+    ""
+
+  eq. ++> can-slice-foreign-literals
+    "hello, 大家!".slice
+      7
+      1
+    "大"
+
+  eq. ++> can-slice-four-byte-characters
+    "One 😀 and 😀 another".slice
+      3
+      8
+    " 😀 and 😀"
+
+  eq. ++> can-slice-from-the-end
+    "hello".slice
+      4
+      1
+    "o"
+
+  eq. ++> can-slice-from-the-start
+    "hello".slice
+      0
+      1
+    "h"
+
+  eq. ++> can-slice-in-the-middle
+    "hello".slice
+      2
+      3
+    "llo"
+
+  eq. ++> can-slice-nothing
+    "no slice".slice
+      0
+      0
+    ""
+
+  eq. ++> can-slice-the-origin-string
+    slice
+      "Hello, world!"
+      7
+      5
+    "world"
+
+  eq. ++> can-slice-three-byte-characters
+    "The अ is अ".slice
+      1
+      6
+    "he अ i"
+
+  eq. ++> can-slice-two-byte-characters
+    "привет".slice
+      1
+      2
+    "ри"
+
+  slice --> stops-on-a-start-below-zero
+    "some string"
+    -1
+    1
+
+  slice --> stops-on-an-end-below-the-start
+    "some string"
+    2
+    -1
+
+  slice --> stops-on-an-end-beyond-the-length
+    "some string"
+    7
+    5

--- a/objects/string/split.eo
+++ b/objects/string/split.eo
@@ -1,0 +1,93 @@
+# Returns a `tuple` of `strings`: `text` separated by `delimiter`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text delimiter] > split
+  if. > @
+    eq.
+      size. >> len!
+        text >> bts!
+      0
+    *
+    [accum start current] >> rec-split
+      if. > @
+        len.eq current
+        appended
+        if.
+          or.
+            size.eq 0
+            gt.
+              current.plus size
+              len
+          rec-split
+            accum
+            start
+            as-number.
+              current.plus 1
+          if.
+            delim.eq
+              bts.slice current size
+            rec-split
+              appended
+              as-number.
+                current.plus size
+              as-number.
+                current.plus size
+            rec-split
+              accum
+              start
+              as-number.
+                current.plus 1
+      accum.with > appended
+        string
+          bts.slice
+            start
+            current.minus start
+    |
+      *
+      0
+      0
+  size. >> size!
+    delimiter >> delim!
+
+  eq. ++> can-split-a-text-into-empty-strings
+    split
+      "-a-b-"
+      "-"
+    *
+      ""
+      "a"
+      "b"
+      ""
+
+  eq. ++> can-split-a-text-on-a-dash
+    split
+      "a-b-c"
+      "-"
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> can-split-a-text-on-a-multi-character-delimiter
+    split
+      "a::b::c"
+      "::"
+    *
+      "a"
+      "b"
+      "c"
+
+  eq. ++> can-split-into-strings
+    length.
+      at.
+        split
+          "hello world!"
+          " "
+        1
+    6

--- a/objects/string/starts-with.eo
+++ b/objects/string/starts-with.eo
@@ -1,0 +1,30 @@
+# Checks that `text` starts with `substring`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text substring] > starts-with
+  and. > @
+    lte.
+      number
+        part.size >> size!
+      txt.size >> length!
+    eq.
+      slice.
+        text >> txt!
+        0
+        size
+      substring >> part!
+
+  starts-with ++> can-start-with-a-substring
+    "Hello, world"
+    "Hello"
+
+  not. ++> cannot-start-with-an-absent-substring
+    starts-with
+      "Hello, world"
+      "world"

--- a/objects/string/trimmed-left.eo
+++ b/objects/string/trimmed-left.eo
@@ -1,0 +1,84 @@
+# Returns `text` trimmed from left side.
+# Removes all leading ASCII whitespace bytes: `20-` (space), `09-`
+# (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
+# (form feed), and `0D-` (carriage return). Matches the strip-set
+# used by `String.strip()` in Java for the ASCII range.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > trimmed-left
+  if. > @
+    0.eq
+      b.size >> len!
+    text
+    string
+      slice.
+        text >> b!
+        first-non-ws-index 0 >> idx!
+        minus.
+          number len
+          idx
+  [index] >> first-non-ws-index
+    if. > @
+      len.eq index
+      index
+      if.
+        is-ws (b.slice index 1)!
+        first-non-ws-index (index.plus 1).as-number
+        index
+  or. > [c] >> is-ws
+    c.eq 20-
+    or.
+      c.eq 09-
+      or.
+        c.eq 0A-
+        or.
+          c.eq 0B-
+          or.
+            c.eq 0C-
+            c.eq 0D-
+
+  eq. ++> can-trim-a-leading-carriage-return
+    trimmed-left "\rvalue"
+    "value"
+
+  eq. ++> can-trim-a-leading-form-feed
+    trimmed-left "\fvalue"
+    "value"
+
+  eq. ++> can-trim-a-leading-line-feed
+    trimmed-left "\nvalue"
+    "value"
+
+  eq. ++> can-trim-a-leading-tab
+    trimmed-left "\tvalue"
+    "value"
+
+  eq. ++> can-trim-a-text-of-leading-spaces-only
+    trimmed-left
+      "     "
+    ""
+
+  eq. ++> can-trim-an-empty-text
+    trimmed-left ""
+    ""
+
+  eq. ++> can-trim-many-leading-spaces
+    trimmed-left
+      "     some"
+    "some"
+
+  eq. ++> can-trim-mixed-leading-whitespace
+    trimmed-left
+      " \t\n\f\rvalue"
+    "value"
+
+  eq. ++> can-trim-one-leading-space
+    trimmed-left
+      " s"
+    "s"

--- a/objects/string/trimmed-right.eo
+++ b/objects/string/trimmed-right.eo
@@ -1,0 +1,82 @@
+# Returns `text` trimmed from right side.
+# Removes all trailing ASCII whitespace bytes: `20-` (space), `09-`
+# (horizontal tab), `0A-` (line feed), `0B-` (vertical tab), `0C-`
+# (form feed), and `0D-` (carriage return). Matches the strip-set
+# used by `String.strip()` in Java for the ASCII range.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > trimmed-right
+  if. > @
+    0.eq
+      b.size >> len!
+    text
+    string
+      slice.
+        text >> b!
+        0
+        [index] >> first-non-ws-index
+          if. > @
+            -1.eq index
+            0
+            if.
+              is-ws (b.slice index 1)!
+              first-non-ws-index (index.plus -1).as-number
+              index.plus 1
+        | ((number len).plus -1)
+  or. > [c] >> is-ws
+    c.eq 20-
+    or.
+      c.eq 09-
+      or.
+        c.eq 0A-
+        or.
+          c.eq 0B-
+          or.
+            c.eq 0C-
+            c.eq 0D-
+
+  eq. ++> can-trim-a-text-of-trailing-spaces-only
+    trimmed-right
+      "     "
+    ""
+
+  eq. ++> can-trim-a-trailing-carriage-return
+    trimmed-right "value\r"
+    "value"
+
+  eq. ++> can-trim-a-trailing-form-feed
+    trimmed-right "value\f"
+    "value"
+
+  eq. ++> can-trim-a-trailing-line-feed
+    trimmed-right "value\n"
+    "value"
+
+  eq. ++> can-trim-a-trailing-tab
+    trimmed-right "value\t"
+    "value"
+
+  eq. ++> can-trim-an-empty-text
+    trimmed-right ""
+    ""
+
+  eq. ++> can-trim-many-trailing-spaces
+    trimmed-right
+      "some     "
+    "some"
+
+  eq. ++> can-trim-mixed-trailing-whitespace
+    trimmed-right
+      "value \t\n\f\r"
+    "value"
+
+  eq. ++> can-trim-one-trailing-space
+    trimmed-right
+      "s "
+    "s"

--- a/objects/string/trimmed.eo
+++ b/objects/string/trimmed.eo
@@ -1,0 +1,63 @@
+# Returns `text` trimmed from both sides.
+# Removes all leading and trailing ASCII whitespace bytes: `20-`
+# (space), `09-` (horizontal tab), `0A-` (line feed), `0B-` (vertical
+# tab), `0C-` (form feed), and `0D-` (carriage return). Delegates to
+# `string.trimmed-left` and `string.trimmed-right`, so the strip-set matches
+# `String.strip()` in Java for the ASCII range.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > trimmed
+  if. > @
+    0.eq text.as-bytes.size
+    text
+    trimmed-left
+      trimmed-right text
+
+  eq. ++> can-preserve-inner-content
+    trimmed "no-whitespace"
+    "no-whitespace"
+
+  eq. ++> can-preserve-inner-whitespace
+    trimmed
+      "\t hello world \n"
+    "hello world"
+
+  eq. ++> can-trim-a-text-of-spaces-only
+    trimmed
+      "        "
+    ""
+
+  eq. ++> can-trim-an-empty-text
+    trimmed ""
+    ""
+
+  eq. ++> can-trim-many-surrounding-spaces
+    trimmed
+      "    some     "
+    "some"
+
+  eq. ++> can-trim-mixed-whitespace-on-both-sides
+    trimmed
+      " \t\n\f\rvalue \t\n\f\r"
+    "value"
+
+  eq. ++> can-trim-one-leading-space
+    trimmed
+      " some"
+    "some"
+
+  eq. ++> can-trim-one-space-on-both-sides
+    trimmed
+      " some "
+    "some"
+
+  eq. ++> can-trim-one-trailing-space
+    trimmed
+      "some "
+    "some"

--- a/objects/string/up-cased.eo
+++ b/objects/string/up-cased.eo
@@ -1,0 +1,41 @@
+# Returns the `text` in upper case.
+
++alias tuple.reduced
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package string
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[text] > up-cased
+  string > @
+    tuple.reduced
+      text.as-bytes.array
+      --
+      [accum byte] >>
+        accum.concat > @
+          if.
+            and.
+              code.lte (as-ascii "z")!
+              code.gte mincode
+            slice.
+              as-bytes.
+                as-i64.
+                  code.minus
+                    minus.
+                      number mincode
+                      as-ascii "A"
+              7
+              1
+            byte
+        as-ascii byte > code
+  as-ascii "a" >> mincode!
+
+  eq. ++> can-convert-already-upper-cased-text
+    "HELLO"
+    up-cased "HeLlO"
+
+  eq. ++> can-convert-text-to-upper-case
+    "HELLO"
+    up-cased "hello"

--- a/objects/switch.eo
+++ b/objects/switch.eo
@@ -1,12 +1,4 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint redundant-object
-+unlint mandatory-package
-
-# The object allows choosing the right options according to case conditions.
+# Object that allows choosing the right options according to case conditions.
 # Parameter `cases` is an array of two-dimensional arrays, which
 # consist of condition bool value and expected value, if this
 # condition is true. For example:
@@ -23,110 +15,97 @@
 # ```
 #
 # This object returns the value of the first true statement.
-[cases] > switch
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[cases fallback] > switch
   if. > @
     cases.length.eq 0
-    error "Switch cases are empty"
+    fallback
+      "Switch cases are empty"
     if.
-      true.eq found.match
+      true.eq
+        match.
+          @. >> found
+            [tup] >> rec-case
+              if. > @
+                and.
+                  tup.length.gt 1
+                  previous.match
+                previous
+                [] >>
+                  tup.head.head > head
+                  tup.head.tail.head > match!
+              @. > previous
+                rec-case tup.tail
+            | cases
       found.head
       true
-  (rec-case cases).@ > found
 
-  # Recursively searches tuple for the first case with true condition.
-  [tup] > rec-case
-    if. > @
-      and.
-        tup.length.gt 1
-        previous.match
-      previous
-      [] >>
-        tup.head.tail.head > match!
-        tup.head.head > head
-    (rec-case tup.tail).@ > previous
+  switch * ++> can-return-true-when-all-cases-are-false
+    *
+      false
+      "false1"
+    *
+      false
+      "false2"
 
-  # Tests that switch returns the value from the first true condition case.
-  [] +> tests-switch-simple-case
+  ++> can-switch-on-a-complex-case
     eq. > @
-      switch
+      switch *
         *
-          *
-            false
-            "1"
-          *
-            true
-            "2"
-      "2"
+          c1 > [] >>
+          22
+        *
+          c2 > [] >>
+          0
+        *
+          c3 > [] >>
+          "true case"
+      "true case"
+    false > c1
+    "1".eq "2" > c2
+    true > c3
 
-  # Tests that switch works correctly with string comparison conditions.
-  [] +> tests-switch-strings-case
+  eq. ++> can-switch-on-a-simple-case
+    switch *
+      * false "1"
+      * true "2"
+    "2"
+
+  ++> can-switch-on-strings
     eq. > @
-      switch
+      switch *
         *
-          *
-            password.eq "swordfish"
-            "password is correct!"
-          *
-            password.eq ""
-            "empty password is not allowed"
-          *
-            false
-            "password is wrong"
+          password.eq "swordfish"
+          "password is correct!"
+        *
+          password.eq ""
+          "empty password is not allowed"
+        *
+          false
+          "password is wrong"
       "password is correct!"
     "swordfish" > password
 
-  # Tests that switch returns the value from the first true case when multiple cases are true.
-  [] +> tests-switch-with-several-true-cases
-    eq. > @
-      switch
-        *
-          *
-            true
-            "TRUE1"
-          *
-            false
-            "FALSE"
-          *
-            true
-            "TRUE2"
-      "TRUE1"
+  eq. ++> can-switch-on-the-first-of-several-true-cases
+    switch *
+      * true "TRUE1"
+      * false "FALSE"
+      * true "TRUE2"
+    "TRUE1"
 
-  # Tests that switch returns true when all cases are false.
-  [] +> tests-switch-with-all-false-cases
-    switch > @
+  eq. ++> rejects-an-empty-switch
+    "recovered"
+    switch
       *
-        *
-          false
-          "false1"
-        *
-          false
-          "false2"
+      "recovered" > [message]
 
-  # Tests that switch throws an error when given empty cases array.
-  [] +> throws-on-empty-switch
-    switch * > @
-
-  # Tests that switch works correctly with complex nested conditions and custom objects.
-  [] +> tests-switch-complex-case
-    eq. > @
-      switch
-        *
-          *
-            [] >>
-              c1 > @
-            22.0
-          *
-            [] >>
-              c2 > @
-            0.0
-          *
-            [] >>
-              c3 > @
-            "true case"
-      "true case"
-    # Condition that evaluates to false for testing purposes.
-    false > c1
-    # Condition that compares unequal strings returning false.
-    "1".eq "2" > c2
-    # Condition that evaluates to true for testing purposes.
-    true > c3
+  switch --> stops-on-an-empty-switch
+    *

--- a/objects/true.eo
+++ b/objects/true.eo
@@ -1,12 +1,16 @@
+# TRUE boolean state.
+# It is the `bool` whose choice returns its first argument, so `if` picks
+# the `left` branch and the byte representation is `01-`.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint mandatory-package
 
-# The object is a TRUE boolean state.
-# It is the `bool` whose choice returns its first argument, so `if` picks
-# the `left` branch and the byte representation is `01-`.
 bool > true
-  left > [left right]
+  []
+    ? >> left
+    ? >> right
+    left > @

--- a/objects/tuple.eo
+++ b/objects/tuple.eo
@@ -1,229 +1,334 @@
+# Tuple.
+# An ordered, immutable collection of elements.
+
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
-+version 0.61.3
++version 0.62.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 +unlint redundant-object
 +unlint mandatory-package
 
-# Tuple.
-# An ordered, immutable collection of elements.
 [tail head length] > tuple
-  # Empty tuple.
-  # A tuple with no elements. When dataized, it represents an immutable, empty collection.
-  tuple > empty
-    error "Can't get tail from the empty tuple"
-    error "Can't get head from the empty tuple"
-    0
-
-  # Take one element from the tuple, at the given position.
-  [i] > at
+  [i fallback] > at
     if. > @
       or.
-        0.gt index
+        0.gt
+          if. >> index!
+            0.gt
+              i >> idx!
+            length.plus idx
+            idx
         length.lte index
-      error "Given index is out of tuple bounds"
-      at-fast ^
-    i > idx!
-    if. > index!
-      0.gt idx
-      length.plus idx
-      idx
-
-    # Recursively traverses tuple tail until reaching the target index.
-    [tup] > at-fast
-      if. > @
-        (tup.length.plus -1).eq index
-        tup.head
-        at-fast tup.tail
-
-  # Create a new tuple with this element added to the end of it.
-  [x] > with
-    tuple > @
-      ^
-      x
-      (length.plus 1).as-number
-
-  # Tests that tuple creation through special syntax (* 1 2) works correctly.
-  [] +> tests-makes-tuple-through-special-syntax
-    eq. > @
-      (* 1 2).length
-      2
-
-  # Tests that empty tuple length can be obtained through special syntax (*.length).
-  [] +> tests-gets-lengths-of-empty-tuple-through-special-syntax
-    eq. > @
-      *.length
-      0
-
-  # Check that an empty tuple's .length equals zero.
-  [] +> tests-empty-tuple-length
-    eq. > @
-      (arr *).elements.length
-      0
-    # Wrapper object that holds elements tuple for testing purposes.
-    [elements] > arr
-
-  # Check that tuple.length works properly for non-empty tuples.
-  [] +> tests-non-empty-tuple-length-test
-    eq. > @
-      arr
-        * "a" "b" "c" "d" "e"
-      .elements
-      .length
-      5
-    # Wrapper object that holds elements tuple for testing purposes.
-    [elements] > arr
-
-  # Tests that a tuple bound as an attribute with size 0 has correct length.
-  [] +> tests-tuple-as-a-bound-attribute-size-0
-    eq. > @
-      tup.length
-      0
-    * > tup
-
-  # Tests that a tuple bound as an attribute with size 1 allows element access.
-  [] +> tests-tuple-as-a-bound-attribute-size-1
-    eq. > @
-      tup.at 0
-      100
-    * > tup
-      100
-
-  # Tests that a tuple bound as an attribute with size 2 allows access to both elements.
-  [] +> tests-tuple-as-a-bound-attribute-size-2
+      fallback
+        "Given index is out of tuple bounds"
+      if. > [tup] >> at-fast
+        0.eq tup.length
+        fallback
+          "Given index is out of tuple bounds"
+        if.
+          eq.
+            tup.length.plus -1
+            index
+          tup.head
+          at-fast tup.tail
+      | ^
+  tuple > empty
+    T
+      "Can't get tail from the empty tuple"
+    T
+      "Can't get head from the empty tuple"
+    0
+  [other] > eq
     and. > @
-      eq.
-        arr.at 0
-        1
-      eq.
-        arr.at 1
-        2
-    * > arr
-      1
-      2
+      length.eq other.length
+      if. > [first second] >> receq
+        first.length.eq 0
+        true
+        and.
+          first.head.eq second.head
+          receq first.tail second.tail
+      | ^ other
+  tuple > [x] > with
+    ^
+    x
+    as-number.
+      length.plus 1
 
-  # Tests that the with method correctly adds an element to an existing tuple.
-  [] +> tests-tuple-with
+  ++> can-add-an-item
     and. > @
       and.
         and.
           eq.
-            arr.at 0
+            array.at 0
             1
           eq.
-            arr.at 1
+            array.at 1
             2
         eq.
-          arr.at 2
+          array.at 2
           3
       eq.
-        arr.at 3
+        array.at 3
         "with"
-    with. > arr
-      * 1 2 3
+    with. > array
+      *
+        1
+        2
+        3
       "with"
 
-  # Tests that accessing a tuple with an out-of-bounds index throws an error.
-  [] +> throws-on-wrong-tuple-at
-    at. > @
-      * 1 2 3 4
-      20
+  ++> can-be-a-bound-attribute-of-one-item
+    eq. > @
+      tup.at 0
+      100
+    * 100 > tup
 
-  # Tests that fluent chaining of with method works correctly for tuple construction.
-  [] +> tests-tuple-fluent-with
+  ++> can-be-a-bound-attribute-of-two-items
+    and. > @
+      eq.
+        array.at 0
+        1
+      eq.
+        array.at 1
+        2
+    * > array
+      1
+      2
+
+  ++> can-be-a-bound-attribute-when-empty
+    tup.length.eq 0 > @
+    * > tup
+
+  ++> can-build-a-tuple-fluently
     and. > @
       and.
         eq.
-          arr.at 0
+          array.at 0
           1
         eq.
-          arr.at 1
+          array.at 1
           2
       eq.
-        arr.at 2
+        array.at 2
         3
-    ((*.with 1).with 2).with 3 > arr
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
 
-  # Tests that fluent chaining of with method works correctly with indented syntax.
-  [] +> tests-tuple-fluent-with-indented
+  ++> can-build-a-tuple-fluently-when-indented
     and. > @
       and.
         eq.
-          arr.at 0
+          array.at 0
           1
         eq.
-          arr.at 1
+          array.at 1
           2
       eq.
-        arr.at 2
+        array.at 2
         3
-    ((*.with 1).with 2).with 3 > arr
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
 
-  # Tests that the length of an explicitly created empty tuple is zero.
-  [] +> tests-gets-lengths-of-empty-tuple
-    eq. > @
-      a.length
+  ++> can-build-an-empty-tuple-with-an-indented-keyword
+    and. > @
+      and.
+        eq.
+          array.at 0
+          1
+        eq.
+          array.at 1
+          2
+      eq.
+        array.at 2
+        3
+    with. > array
+      with.
+        tuple.empty.with 1
+        2
+      3
+
+  tuple.contains ++> can-check-containment-through-the-package
+    *
+      1
+      2
+      3
+    2
+
+  eq. ++> can-concat-with-another-tuple
+    concat.
+      * 0 1
+      * 2 3
+    *
       0
-    tuple.empty > a
+      1
+      2
+      3
 
-  # Tests that the length of an empty tuple can be accessed directly without intermediate objects.
-  [] +> tests-gets-lengths-of-empty-tuple-without-additional-obj
-    eq. > @
-      tuple.empty.length
-      0
+  contains. ++> can-contain-an-element
+    *
+      1
+      2
+      3
+    2
 
-  # Tests that adding a number to an empty tuple creates a tuple with that element.
-  [] +> tests-creates-empty-tuple-with-number
+  ++> can-create-an-empty-tuple-with-a-number
     eq. > @
       a.at 0
       3
     tuple.empty.with 3 > a
 
-  # Tests that the at-fast method correctly retrieves the first element of a tuple.
-  [] +> tests-at-fast-with-first-element
-    eq. > @
-      (arr.at 0).at-fast arr
-      100
-    * 100 101 102 > arr
+  eq. ++> can-equal-a-nested-tuple
+    *
+      * 0 1
+      * 4 0
+      * 7 3
+    *
+      * 0 1
+      * 4 0
+      * 7 3
 
-  # Tests that the at-fast method correctly retrieves the last element of a tuple.
-  [] +> tests-at-fast-with-last-element
-    eq. > @
-      (arr.at 2).at-fast arr
-      102
-    * 100 101 102 > arr
+  eq. ++> can-equal-another-tuple
+    *
+      1
+      2
+      3
+    *
+      1
+      2
+      3
 
-  # Tests that fluent chaining starting from empty tuple works with indented keyword syntax.
-  [] +> tests-tuple-empty-fluent-with-indented-keyword
-    and. > @
-      and.
-        eq.
-          arr.at 0
-          1
-        eq.
-          arr.at 1
-          2
-      eq.
-        arr.at 2
-        3
-    ((tuple.empty.with 1).with 2).with 3 > arr
+  eq. ++> can-find-the-index-of-an-element
+    index-of.
+      *
+        10
+        20
+        30
+      20
+    1
 
-  # Tests that using negative index -1 correctly retrieves the last element of the tuple.
-  [] +> tests-tuple-with-negative-index-gets-last
-    eq. > @
-      arr.at -1
-      4
-    * 0 1 2 3 4 > arr
+  ++> can-get-the-length-of-an-empty-tuple
+    a.length.eq 0 > @
+    * > a
 
-  # Tests that using negative index -5 correctly retrieves the first element of a 5-element tuple.
-  [] +> tests-tuple-with-negative-index-gets-first
+  tuple.empty.length.eq ++> can-get-the-length-of-an-empty-tuple-through-special-syntax
+    0
+
+  tuple.empty.length.eq ++> can-get-the-length-of-an-empty-tuple-without-an-extra-object
+    0
+
+  eq. ++> can-make-a-tuple-through-special-syntax
+    length.
+      * 1 2
+    2
+
+  ++> can-report-the-length-of-a-non-empty-tuple
     eq. > @
-      arr.at -5
+      length.
+        elements.
+          array *
+            "a"
+            "b"
+            "c"
+            "d"
+            "e"
+      5
+    [elements] > array
+
+  ++> can-report-the-length-of-an-empty-tuple
+    eq. > @
+      length.
+        elements.
+          array
+            *
       0
-    * 0 1 2 3 4 > arr
+    [elements] > array
 
-  # Tests that accessing a tuple with an out-of-bounds negative index throws an error.
-  [] +> throws-on-out-of-tuple-bounds-with-negative-index
-    arr.at -6 > @
-    * 0 1 2 3 4 > arr
+  ++> can-take-the-first-item-by-a-negative-index
+    eq. > @
+      array.at -5
+      0
+    * > array
+      0
+      1
+      2
+      3
+      4
+
+  ++> can-take-the-last-item-by-a-negative-index
+    eq. > @
+      array.at -1
+      4
+    * > array
+      0
+      1
+      2
+      3
+      4
+
+  not. ++> cannot-contain-an-absent-element
+    contains.
+      *
+        1
+        2
+        3
+      5
+
+  not. ++> cannot-equal-a-different-tuple
+    eq.
+      *
+        1
+        2
+        3
+      *
+        3
+        2
+        1
+
+  eq. ++> rejects-a-fractional-index
+    "recovered"
+    at.
+      *
+        "zero"
+        "one"
+        "two"
+      1.5
+      "recovered" > [message]
+
+  eq. ++> rejects-an-out-of-bounds-index
+    "recovered"
+    at.
+      *
+        1
+        2
+        3
+        4
+      20
+      "recovered" > [message]
+
+  at. --> stops-on-a-wrong-index
+    *
+      1
+      2
+      3
+      4
+    20
+
+  --> stops-on-an-out-of-bounds-negative-index
+    array.at -6 > @
+    * > array
+      0
+      1
+      2
+      3
+      4
+
+  tuple.empty.head --> stops-on-taking-the-head-of-an-empty-tuple
+
+  tuple.empty.tail --> stops-on-taking-the-tail-of-an-empty-tuple

--- a/objects/tuple/back.eo
+++ b/objects/tuple/back.eo
@@ -1,0 +1,61 @@
+# Last `index` elements of `list` (an `index` larger than `list.length`
+# returns the whole `list`).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list index] > back
+  if. > @
+    0.gt
+      list.length.minus index! >> start!
+    list
+    reducedi
+      list
+      *
+      if. > [accum item idx] >>
+        idx.gte start
+        accum.with item
+        accum
+
+  eq. ++> can-take-a-back-slice
+    back
+      *
+        1
+        2
+        3
+        4
+        5
+      2
+    *
+      4
+      5
+
+  eq. ++> can-take-a-back-slice-with-a-large-index
+    back
+      *
+        1
+        2
+        3
+        4
+        5
+      10
+    *
+      1
+      2
+      3
+      4
+      5
+
+  is-empty ++> can-take-a-back-slice-with-a-zero-index
+    back
+      *
+        1
+        2
+        3
+        4
+        5
+      0

--- a/objects/tuple/concat.eo
+++ b/objects/tuple/concat.eo
@@ -1,0 +1,43 @@
+# Concatenate `list` with another collection `passed`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list passed] > concat
+  reducedi > @
+    passed
+    list
+    with > [accum item index]
+      accum
+      item
+
+  ++> can-concat-two-lists
+    and. > @
+      1.eq
+        list3.at 0
+      list3.eq
+        *
+          1
+          2
+          3
+    withouti > list3
+      concat *1
+        * 0 1
+        2
+        3
+      0
+
+  eq. ++> can-concat-with-a-tuple
+    concat *1
+      * 0 1
+      2
+      4
+    *
+      0
+      1
+      2
+      4

--- a/objects/tuple/contains.eo
+++ b/objects/tuple/contains.eo
@@ -1,0 +1,38 @@
+# Returns `true` if `list` contains `element`, `false` otherwise.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list element] > contains
+  not. > @
+    -1.eq
+      index-of list element
+
+  contains ++> can-contain-a-number
+    *
+      "qwerty"
+      "asdfgh"
+      3
+      "qwerty"
+    3
+
+  contains ++> can-contain-a-string
+    *
+      "qwerty"
+      "asdfgh"
+      3
+      "qwerty"
+    "qwerty"
+
+  not. ++> cannot-contain-an-absent-item
+    contains
+      *
+        "Привет"
+        "asdfgh"
+        3
+        "qwerty"
+      "Hi"

--- a/objects/tuple/each.eo
+++ b/objects/tuple/each.eo
@@ -1,0 +1,61 @@
+# For each collection element dataize the object.
+# Here "func" must be an abstract object with one free attribute:
+# the element of the collection. The result of `func` must be dataizable.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > each
+  eachi > @
+    list
+    func item > [item index] >>
+
+  ++> can-iterate-over-a-list
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            * 1 2 3
+            m.put > [i] >>
+              m.as-number.plus i
+      6
+
+  eq. ++> can-return-the-result-of-the-last-call
+    each
+      *
+        1
+        2
+        3
+      x > [x]
+    3
+
+  ++> can-sum-many-numbers
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            * 10 20 30
+            m.put > [i] >>
+              m.as-number.plus i
+      60
+
+  ++> can-walk-a-single-element-list
+    eq. > @
+      malloc.for
+        0
+        [m]
+          each > @
+            * 7
+            m.put > [i] >>
+              m.as-number.plus i
+      7
+
+  each ++> can-walk-an-empty-list
+    *
+    false > [x]

--- a/objects/tuple/eachi.eo
+++ b/objects/tuple/eachi.eo
@@ -1,0 +1,33 @@
+# For each collection element dataize the object
+# Here "func" must be an abstract object with
+# two free attributes: the element of the
+# collection and its index.
+# The result of `func` must be dataizable.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > eachi
+  reducedi > @
+    list
+    true
+    seq * > [acc item index] >>
+      acc
+      func item index
+
+  ++> can-iterate-over-a-list-with-indexes
+    eq. > @
+      malloc.for
+        0
+        [m]
+          eachi > @
+            * 1 2 3
+            m.put > [item index] >>
+              plus.
+                m.as-number.plus item
+                index
+      9

--- a/objects/tuple/filtered.eo
+++ b/objects/tuple/filtered.eo
@@ -1,0 +1,40 @@
+# Filter `list` without index with the function `func`.
+# Here `func` must be an abstract object
+# with one attribute for the element.
+# The result of dataization the `func`
+# should be boolean, that is `true` or `false`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > filtered
+  filteredi > @
+    list
+    func item > [item index] >>
+
+  eq. ++> can-filter-a-list
+    filtered
+      *
+        3
+        1
+        4
+        2
+        5
+      v.gt 2 > [v]
+    *
+      3
+      4
+      5
+
+  eq. ++> can-filter-bools
+    filtered
+      *
+        true
+        false
+        true
+      v.not > [v]
+    * false

--- a/objects/tuple/filteredi.eo
+++ b/objects/tuple/filteredi.eo
@@ -1,0 +1,73 @@
+# Filter `list` with index with the function `func`.
+# Here `func` must be an abstract
+# object with two attributes. The first
+# one for the element, the second one
+# for the index. The result of dataization
+# the `func` should be boolean, that is `true` or `false`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > filteredi
+  [tup] >> recfilter
+    if. > @
+      tup.length.eq 0
+      *
+      if.
+        func tup.head tup.tail.length
+        next.with tup.head
+        next
+    recfilter tup.tail > next
+  | list > @
+
+  eq. ++> can-filter-by-a-less-than-condition
+    filteredi
+      *
+        3
+        1
+        4
+        2
+        5
+      v.lt 3 > [v i]
+    *
+      1
+      2
+
+  eq. ++> can-filter-by-string-length
+    filteredi
+      *
+        "Hello"
+        "Name"
+        "EO"
+        "List"
+      v.length.gt 4 > [v i]
+    * "Hello"
+
+  is-empty ++> can-filter-an-empty-list
+    filteredi
+      *
+      v.lt 3 > [v i]
+
+  eq. ++> can-filter-by-index
+    filteredi
+      *
+        3
+        1
+        4
+      i.gt 0 > [v i]
+    *
+      1
+      4
+
+  eq. ++> can-filter-bools-with-indexes
+    filteredi
+      *
+        true
+        false
+        true
+      v.not > [v i]
+    * false

--- a/objects/tuple/front.eo
+++ b/objects/tuple/front.eo
@@ -1,0 +1,95 @@
+# Elements of `list` before `index` (supports negative indices).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list index] > front
+  if. > @
+    idx.eq 0
+    *
+    if.
+      0.gt
+        index >> idx!
+      back
+        list
+        neg.
+          number idx
+      if.
+        gte.
+          number idx
+          list.length
+        list
+        if. > [tup] >> rechead
+          tup.length.eq idx
+          tup
+          rechead tup.tail
+        | list
+
+  eq. ++> can-take-a-front-slice
+    front
+      *
+        1
+        2
+        3
+        4
+        5
+      1
+    * 1
+
+  eq. ++> can-take-a-front-slice-of-a-complex-list
+    front
+      *
+        "foo"
+        2.2
+        00-01
+        "bar"
+      2
+    *
+      "foo"
+      2.2
+
+  eq. ++> can-take-a-front-slice-of-a-complex-list-with-a-negative-index
+    front
+      *
+        "foo"
+        2.2
+        00-01
+        "bar"
+      -3
+    *
+      2.2
+      00-01
+      "bar"
+
+  eq. ++> can-take-a-front-slice-with-a-negative-index
+    front
+      *
+        1
+        2
+        3
+      -1
+    * 3
+
+  is-empty ++> can-take-a-front-slice-with-a-zero-index
+    front
+      *
+        1
+        2
+        3
+      0
+
+  eq. ++> can-take-a-front-slice-with-the-length-as-index
+    front
+      *
+        1
+        2
+        3
+      3
+    *
+      1
+      2
+      3

--- a/objects/tuple/index-of.eo
+++ b/objects/tuple/index-of.eo
@@ -1,0 +1,60 @@
+# Returns index of the first occurrence of `wanted` in `list`.
+# If `list` has no such element, returns -1.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list wanted] > index-of
+  number > @
+    [tup] >> recidx
+      if. > @
+        tup.length.eq 0
+        -1
+        if.
+          next.eq -1
+          if.
+            tup.head.eq wanted
+            tup.tail.length
+            -1
+          recidx tup.tail >> next!
+    | list
+
+  eq. ++> can-find-the-index-of-a-string
+    1
+    index-of
+      *
+        "asdfgh"
+        "qwerty"
+        3
+      "qwerty"
+
+  eq. ++> can-return-the-first-index-of-an-element
+    0
+    index-of
+      *
+        -1
+        2
+        -1
+      -1
+
+  eq. ++> can-return-the-index-of-an-element
+    1
+    index-of
+      *
+        1
+        2
+        3
+      2
+
+  eq. ++> cannot-find-the-index-of-an-absent-item
+    -1
+    index-of
+      *
+        "qwerty"
+        2
+        3
+      7

--- a/objects/tuple/is-empty.eo
+++ b/objects/tuple/is-empty.eo
@@ -1,0 +1,33 @@
+# True when collection `list` has no elements.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list] > is-empty
+  0.eq list.length > @
+
+  is-empty ++> can-be-empty-when-built-empty
+    *
+
+  ++> cannot-be-empty-with-one-anonymous-object
+    not. > @
+      is-empty xs
+    * > xs
+      [f]
+
+  not. ++> cannot-be-empty-with-one-item
+    is-empty *
+      1
+      2
+
+  ++> cannot-be-empty-with-three-objects
+    not. > @
+      is-empty xs
+    * > xs
+      [x]
+      [y]
+      [z]

--- a/objects/tuple/last-index-of.eo
+++ b/objects/tuple/last-index-of.eo
@@ -1,0 +1,63 @@
+# Returns index of the last occurrence of `wanted` in `list`.
+# If `list` has no such element, returns -1.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list wanted] > last-index-of
+  if. > [t] >> rec
+    t.length.eq 0
+    -1
+    if.
+      t.head.eq wanted
+      t.tail.length
+      rec t.tail
+  | list > @
+
+  eq. ++> can-find-the-last-index-of-an-item
+    1
+    last-index-of
+      *
+        "qwerty"
+        2
+        3
+      2
+
+  eq. ++> can-find-the-last-index-of-a-repeated-item
+    2
+    last-index-of
+      *
+        24
+        42
+        24
+      24
+
+  eq. ++> cannot-find-the-last-index-of-an-absent-item
+    -1
+    last-index-of
+      *
+        1
+        2
+        3
+      0
+
+  eq. ++> cannot-find-the-last-index-in-an-empty-list
+    -1
+    last-index-of
+      *
+      "abc"
+
+  eq. ++> can-find-the-last-index-of-a-unicode-item
+    3
+    last-index-of
+      *
+        "Hi"
+        "Привет"
+        "Hola"
+        "Привет"
+        "こんにちわ"
+      "Привет"

--- a/objects/tuple/mapped.eo
+++ b/objects/tuple/mapped.eo
@@ -1,0 +1,27 @@
+# Map `list` without index. Here "func" must be an abstract
+# object with one free attribute, for the element
+# of the collection.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > mapped
+  mappedi > @
+    list
+    func item > [item idx] >>
+
+  eq. ++> can-map-a-list
+    mapped
+      *
+        1
+        2
+        3
+      x.times 2 > [x]
+    *
+      2
+      4
+      6

--- a/objects/tuple/mappedi.eo
+++ b/objects/tuple/mappedi.eo
@@ -1,0 +1,32 @@
+# Map `list` with index. Here "func" must be an abstract
+# object with two free attributes. The first
+# one for the element of the collection, the second one
+# for the index.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list func] > mappedi
+  reducedi > @
+    list
+    *
+    accum.with > [accum item idx] >>
+      func item idx
+
+  eq. ++> can-map-a-list-with-indexes
+    mappedi
+      *
+        1
+        2
+        3
+        4
+      i.times x > [x i]
+    *
+      0
+      2
+      6
+      12

--- a/objects/tuple/maximum.eo
+++ b/objects/tuple/maximum.eo
@@ -1,0 +1,58 @@
+# Maximum `number` in `sequence`, which must be a `tuple` or any `tuple`
+# decorator of `number` objects. An empty sequence has no maximum, so `cant-max`
+# is dataized with an explanatory message and stands in as the result.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[sequence cant-max] > maximum
+  if. > @
+    is-empty sequence
+    cant-max
+      "cannot get the maximum number from an empty sequence"
+    reduced
+      sequence
+      ninf
+      if. > [max item]
+        item.as-number.gt max
+        item
+        max
+
+  eq. ++> can-take-a-maximum-of-one-item
+    maximum
+      * 42
+    42
+
+  eq. ++> can-take-a-maximum-that-is-first
+    maximum *
+      25
+      12
+      -2
+    25
+
+  eq. ++> can-take-a-maximum-that-is-in-the-middle
+    maximum *
+      12
+      25
+      -2
+    25
+
+  eq. ++> can-take-a-maximum-that-is-last
+    maximum *
+      12
+      -2
+      25
+    25
+
+  eq. ++> rejects-an-empty-list
+    "recovered"
+    maximum
+      *
+      "recovered" > [msg]
+
+  maximum --> stops-on-an-empty-list
+    *

--- a/objects/tuple/minimum.eo
+++ b/objects/tuple/minimum.eo
@@ -1,0 +1,58 @@
+# Minimum `number` in `sequence`, which must be a `tuple` or any `tuple`
+# decorator of `number` objects. An empty sequence has no minimum, so `cant-min`
+# is dataized with an explanatory message and stands in as the result.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[sequence cant-min] > minimum
+  if. > @
+    is-empty sequence
+    cant-min
+      "cannot get the minimum number from an empty sequence"
+    reduced
+      sequence
+      pinf
+      if. > [min item]
+        min.gt item.as-number
+        item
+        min
+
+  eq. ++> can-take-a-minimum-of-one-item
+    minimum
+      * 42
+    42
+
+  eq. ++> can-take-a-minimum-that-is-first
+    minimum *
+      -2
+      25
+      12
+    -2
+
+  eq. ++> can-take-a-minimum-that-is-in-the-middle
+    minimum *
+      12
+      -2
+      25
+    -2
+
+  eq. ++> can-take-a-minimum-that-is-last
+    minimum *
+      12
+      25
+      -2
+    -2
+
+  eq. ++> rejects-an-empty-list
+    "recovered"
+    minimum
+      *
+      "recovered" > [msg]
+
+  minimum --> stops-on-an-empty-list
+    *

--- a/objects/tuple/reduced.eo
+++ b/objects/tuple/reduced.eo
@@ -1,0 +1,39 @@
+# Reduce `list` from "start" using the function "func".
+# Here "func" must be an abstract object with two free attributes.
+# The first one for the accumulator, the second one for the element
+# of the collection.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list start func] > reduced
+  reducedi > @
+    list
+    start
+    func > [accum item index] >>
+      accum
+      item
+
+  eq. ++> can-reduce-a-list
+    reduced
+      *
+        1
+        2
+        3
+        4
+      -1
+      a.times x > [a x]
+    -24
+
+  eq. ++> can-reduce-a-list-into-a-string
+    reduced
+      * 0 1
+      ""
+      acc.concat > [acc item]
+        "%d".printf
+          * item
+    "01"

--- a/objects/tuple/reducedi.eo
+++ b/objects/tuple/reducedi.eo
@@ -1,0 +1,113 @@
+# Reduce list with index from "start" using the function "func".
+# Here "func" must be an abstract object with three free attributes.
+# The first one for the accumulator, the second one
+# for the element of the collection and the third one for the index.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list start func] > reducedi
+  if. > @
+    is-empty list
+    start
+    if. > [tup] >> rec-reducedi
+      tup.length.eq 1
+      func
+        start
+        tup.head
+        0
+      func
+        rec-reducedi tup.tail
+        tup.head
+        tup.tail.length
+    | list
+
+  ++> can-reduce-a-list-with-indexes
+    6.eq > @
+      reducedi
+        * 1 1
+        0
+        x.plus > [a x i] >>
+          a.plus
+            at.
+              * 2 2
+              i
+
+  eq. ++> can-reduce-a-long-integer-list-with-indexes
+    reducedi
+      *
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        0
+        1
+      0
+      x.plus a > [a x i]
+    1
+
+  not. ++> can-reduce-bools-with-indexes
+    reducedi
+      *
+        true
+        true
+        false
+      true
+      x.and a > [a x i]
+
+  ++> can-reduce-with-nested-functions
+    eq. > @
+      reducedi
+        * 10 500
+        0
+        [acc x i]
+          check x > @
+          if. > [el] > check
+            x.lt 100
+            acc.plus x
+            acc.minus x
+      10.plus
+        0.minus 500

--- a/objects/tuple/shifted.eo
+++ b/objects/tuple/shifted.eo
@@ -1,0 +1,39 @@
+# Drop the first `shift` elements of `list`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list shift] > shifted
+  slice > @
+    list
+    shift
+    list.length
+
+  eq. ++> can-shift-by-less-than-the-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      2
+    *
+      3
+      4
+      5
+
+  eq. ++> can-shift-by-more-than-the-length
+    shifted
+      *
+        8
+        2
+        3
+        4
+        5
+      6
+    *

--- a/objects/tuple/slice.eo
+++ b/objects/tuple/slice.eo
@@ -1,0 +1,199 @@
+# Sublist of `list` from `start` (inclusive) to `end` (exclusive).
+# Supports negative indices and clamps to list bounds.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list start end] > slice
+  if. > @
+    gte.
+      number
+        if. >> s!
+          start.gte 0
+          if.
+            start.gte list.length
+            list.length
+            start
+          if.
+            list.length.neg.lte start
+            start.plus list.length
+            0
+      if. >> e!
+        end.gte 0
+        if.
+          end.gte list.length
+          list.length
+          end
+        if.
+          list.length.neg.lte end
+          end.plus list.length
+          0
+    *
+    reducedi
+      list
+      *
+      if. > [accum item index] >>
+        and.
+          index.gte s
+          index.lt e
+        accum.with item
+        accum
+
+  eq. ++> can-slice-a-list
+    slice
+      *
+        1
+        2
+        3
+        4
+        5
+      1
+      5
+    *
+      2
+      3
+      4
+      5
+
+  eq. ++> can-slice-with-a-negative-end
+    slice
+      *
+        "a"
+        2
+        3
+        "xyz"
+        82.42
+        7
+      0
+      -1
+    *
+      "a"
+      2
+      3
+      "xyz"
+      82.42
+
+  eq. ++> can-slice-with-a-negative-start
+    slice
+      *
+        8
+        76
+        -3
+        0
+        3
+        8
+        -12
+      -4
+      6
+    *
+      0
+      3
+      8
+
+  eq. ++> can-slice-with-a-negative-start-and-end
+    slice
+      *
+        8
+        23
+        0
+        0
+        "foo"
+      -4
+      -1
+    *
+      23
+      0
+      0
+
+  eq. ++> can-slice-with-a-negative-start-not-below-the-end
+    slice
+      *
+        "f"
+        1
+        "b"
+        2
+        "b"
+        3
+      -1
+      3
+    *
+
+  eq. ++> can-slice-with-a-start-below-the-negative-length
+    slice
+      *
+        9
+        99
+        999
+        9999
+      -10
+      3
+    *
+      9
+      99
+      999
+
+  eq. ++> can-slice-with-a-start-not-below-a-negative-end
+    slice
+      *
+        8
+        -2
+        33-53
+        -1
+        33
+        "Y"
+      4
+      -5
+    *
+
+  eq. ++> can-slice-with-a-start-not-below-the-end-when-both-negative
+    slice
+      *
+        3
+        92
+        -423
+        0
+        22
+        943
+        -22
+      -3
+      -5
+    *
+
+  eq. ++> can-slice-with-a-start-not-below-the-end-when-both-positive
+    slice
+      *
+        3
+        "-5"
+        0
+        "foo"
+      2
+      0
+    *
+
+  eq. ++> can-slice-with-an-end-below-the-negative-length
+    slice
+      *
+        "A"
+        "b"
+        "C"
+        "d"
+        "E"
+      2
+      -9
+    *
+
+  eq. ++> can-slice-with-an-end-beyond-the-length
+    slice
+      *
+        "foo"
+        "bar"
+        "buzz"
+      1
+      10
+    *
+      "bar"
+      "buzz"

--- a/objects/tuple/with.eo
+++ b/objects/tuple/with.eo
@@ -1,0 +1,20 @@
+# Append element `x` to the end of collection `list`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list x] > with
+  list.with x > @
+
+  eq. ++> can-add-an-item
+    with
+      * 1 2
+      3
+    *
+      1
+      2
+      3

--- a/objects/tuple/withi.eo
+++ b/objects/tuple/withi.eo
@@ -1,0 +1,53 @@
+# Insert `item` into collection `list` at the given `index`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list index item] > withi
+  concat > @
+    with
+      front list index
+      item
+    back
+      list
+      list.length.minus index
+
+  eq. ++> can-insert-at-a-zero-index
+    withi
+      *
+        1
+        2
+        3
+        4
+        5
+      0
+      "hello"
+    *
+      "hello"
+      1
+      2
+      3
+      4
+      5
+
+  eq. ++> can-insert-at-an-index
+    withi
+      *
+        1
+        2
+        3
+        4
+        5
+      3
+      "hello"
+    *
+      1
+      2
+      3
+      "hello"
+      4
+      5

--- a/objects/tuple/without.eo
+++ b/objects/tuple/without.eo
@@ -1,0 +1,33 @@
+# Create a new list without all occurrences of `element` in `list`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list element] > without
+  reduced > @
+    list
+    *
+    if. > [accum item] >>
+      element.eq item
+      accum
+      accum.with item
+
+  eq. ++> can-drop-an-item
+    without
+      *
+        1
+        2
+        1
+        2
+        1
+        5
+      2
+    *
+      1
+      1
+      1
+      5

--- a/objects/tuple/withouti.eo
+++ b/objects/tuple/withouti.eo
@@ -1,0 +1,53 @@
+# Create a new list without the i-th element of `list`.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[list i] > withouti
+  reducedi > @
+    list
+    *
+    if. > [accum item index] >>
+      i.eq index
+      accum
+      accum.with item
+
+  eq. ++> can-drop-an-item-by-index
+    withouti
+      *
+        1
+        2
+        3
+      1
+    *
+      1
+      3
+
+  ++> can-drop-an-item-by-index-in-a-complex-list
+    eq. > @
+      foo *
+        1
+        "text"
+        "f"
+      * "text" "f"
+    withouti > [a] > foo
+      a
+      0
+
+  eq. ++> can-drop-an-item-by-index-in-a-nested-list
+    withouti
+      *
+        "smthg"
+        27
+        *
+          3
+          2
+          1
+      2
+    *
+      "smthg"
+      27

--- a/objects/u16.eo
+++ b/objects/u16.eo
@@ -1,0 +1,125 @@
+# Unsigned 16-bit integer.
+# Here `as-bytes` must be a `bytes` object of exactly two bytes,
+# interpreted without a sign.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[as-bytes] > u16
+  as-bytes > @
+  i32 > [] > as-i32
+    00-00.concat as-bytes
+  as-i32.as-number > as-number
+  [x cant-divide] > div
+    if. > @
+      eq.
+        x.as-u16 >> other
+        00-00
+      cant-divide
+        "Can't divide %d by u16 zero".printf
+          * as-number
+      u16
+        slice.
+          as-bytes.
+            as-i32.div other.as-i32
+          2
+          2
+  as-i32.gt x.as-u16.as-i32 > [x] > gt
+  as-i32.gte x.as-u16.as-i32 > [x] > gte
+  as-i32.lt x.as-u16.as-i32 > [x] > lt
+  as-i32.lte x.as-u16.as-i32 > [x] > lte
+  u16 > [x] > minus
+    slice.
+      as-bytes.
+        as-i32.minus x.as-u16.as-i32
+      2
+      2
+  u16 > [x] > plus
+    slice.
+      as-bytes.
+        as-i32.plus x.as-u16.as-i32
+      2
+      2
+  u16 > [x] > times
+    slice.
+      as-bytes.
+        as-i32.times x.as-u16.as-i32
+      2
+      2
+
+  eq. ++> can-add-one-to-one
+    00-01.as-u16.plus 00-01.as-u16
+    00-02.as-u16
+
+  eq. ++> can-add-with-overflow
+    FF-FF.as-u16.plus 00-01.as-u16
+    00-00.as-u16
+
+  00-32.as-u16.gte 00-32.as-u16 ++> can-be-greater-than-or-equal-to-an-equal-u16
+
+  00-0A.as-u16.lt 00-32.as-u16 ++> can-be-less-than-a-larger-u16
+
+  00-32.as-u16.lte 00-32.as-u16 ++> can-be-less-than-or-equal-to-an-equal-u16
+
+  00-00.as-u16.lt FF-FF.as-u16 ++> can-be-less-than-the-maximum-when-zero
+
+  FF-FF.as-u16.as-number.eq 65535 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
+    FF-FF.as-u16.div 00-01.as-u16
+    FF-FF.as-u16
+
+  eq. ++> can-divide-without-a-sign
+    FF-FF.as-u16.div 00-02.as-u16
+    7F-FF.as-u16
+
+  00-2A.as-u16.eq 00-2A.as-u16 ++> can-equal-the-same-u16
+
+  00-2A.as-u16.as-bytes.eq 00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    00-06.as-u16.times 00-07.as-u16
+    00-2A.as-u16
+
+  eq. ++> can-subtract
+    00-05.as-u16.minus 00-03.as-u16
+    00-02.as-u16
+
+  eq. ++> can-subtract-with-underflow
+    00-00.as-u16.minus 00-01.as-u16
+    FF-FF.as-u16
+
+  FF-FF.as-u16.gt 00-01.as-u16 ++> can-treat-a-high-bit-as-magnitude-when-greater
+
+  eq. ++> can-widen-to-i32-with-a-zero-prefix
+    FF-FF.as-u16.as-i32.as-bytes
+    00-00-FF-FF
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixteenth
+    01-00.as-u16.times 01-00.as-u16
+    00-00.as-u16
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u16
+    00-00.as-u16.gte 00-0A.as-u16
+
+  not. ++> cannot-be-less-than-an-equal-u16
+    00-0A.as-u16.lt 00-0A.as-u16
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF.as-u16.lt 00-01.as-u16
+
+  not. ++> cannot-equal-a-different-u16
+    00-2A.as-u16.eq 00-2B.as-u16
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    00-02.as-u16.div
+      00-00.as-u16
+      "recovered" > [message]
+
+  00-02.as-u16.div 00-00.as-u16 --> stops-on-division-by-zero

--- a/objects/u32.eo
+++ b/objects/u32.eo
@@ -1,0 +1,133 @@
+# Unsigned 32-bit integer.
+# Here `as-bytes` must be a `bytes` object of exactly four bytes,
+# interpreted without a sign.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[as-bytes] > u32
+  as-bytes > @
+  i64 > [] > as-i64
+    00-00-00-00.concat as-bytes
+  as-i64.as-number > as-number
+  [x cant-divide] > div
+    if. > @
+      eq.
+        x.as-u32 >> other
+        00-00-00-00
+      cant-divide
+        "Can't divide %d by u32 zero".printf
+          * as-number
+      u32
+        slice.
+          as-bytes.
+            as-i64.div other.as-i64
+          4
+          4
+  as-i64.gt x.as-u32.as-i64 > [x] > gt
+  as-i64.gte x.as-u32.as-i64 > [x] > gte
+  as-i64.lt x.as-u32.as-i64 > [x] > lt
+  as-i64.lte x.as-u32.as-i64 > [x] > lte
+  u32 > [x] > minus
+    slice.
+      as-bytes.
+        as-i64.minus x.as-u32.as-i64
+      4
+      4
+  u32 > [x] > plus
+    slice.
+      as-bytes.
+        as-i64.plus x.as-u32.as-i64
+      4
+      4
+  u32 > [x] > times
+    slice.
+      as-bytes.
+        as-i64.times x.as-u32.as-i64
+      4
+      4
+
+  eq. ++> can-add-one-to-one
+    00-00-00-01.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-02.as-u32
+
+  eq. ++> can-add-with-overflow
+    FF-FF-FF-FF.as-u32.plus 00-00-00-01.as-u32
+    00-00-00-00.as-u32
+
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-u32
+    00-00-00-32.as-u32
+    00-00-00-32.as-u32
+
+  00-00-00-0A.as-u32.lt 00-00-00-32.as-u32 ++> can-be-less-than-a-larger-u32
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-u32
+    00-00-00-32.as-u32
+    00-00-00-32.as-u32
+
+  lt. ++> can-be-less-than-the-maximum-when-zero
+    00-00-00-00.as-u32
+    FF-FF-FF-FF.as-u32
+
+  FF-FF-FF-FF.as-u32.as-number.eq 4294967295 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
+    FF-FF-FF-FF.as-u32.div 00-00-00-01.as-u32
+    FF-FF-FF-FF.as-u32
+
+  eq. ++> can-divide-without-a-sign
+    FF-FF-FF-FF.as-u32.div 00-00-00-02.as-u32
+    7F-FF-FF-FF.as-u32
+
+  00-00-00-2A.as-u32.eq 00-00-00-2A.as-u32 ++> can-equal-the-same-u32
+
+  00-00-00-2A.as-u32.as-bytes.eq 00-00-00-2A ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    00-00-00-06.as-u32.times 00-00-00-07.as-u32
+    00-00-00-2A.as-u32
+
+  eq. ++> can-subtract
+    00-00-00-05.as-u32.minus 00-00-00-03.as-u32
+    00-00-00-02.as-u32
+
+  eq. ++> can-subtract-with-underflow
+    00-00-00-00.as-u32.minus 00-00-00-01.as-u32
+    FF-FF-FF-FF.as-u32
+
+  gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
+    FF-FF-FF-FF.as-u32
+    00-00-00-01.as-u32
+
+  eq. ++> can-widen-to-i64-with-a-zero-prefix
+    FF-FF-FF-FF.as-u32.as-i64.as-bytes
+    00-00-00-00-FF-FF-FF-FF
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-thirty-second
+    00-01-00-00.as-u32.times 00-01-00-00.as-u32
+    00-00-00-00.as-u32
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u32
+    00-00-00-00.as-u32.gte 00-00-00-0A.as-u32
+
+  not. ++> cannot-be-less-than-an-equal-u32
+    00-00-00-0A.as-u32.lt 00-00-00-0A.as-u32
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF-FF-FF.as-u32.lt 00-00-00-01.as-u32
+
+  not. ++> cannot-equal-a-different-u32
+    00-00-00-2A.as-u32.eq 00-00-00-2B.as-u32
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    00-00-00-02.as-u32.div
+      00-00-00-00.as-u32
+      "recovered" > [message]
+
+  00-00-00-02.as-u32.div 00-00-00-00.as-u32 --> stops-on-division-by-zero

--- a/objects/u64.eo
+++ b/objects/u64.eo
@@ -1,0 +1,125 @@
+# Unsigned 64-bit integer.
+# Here `as-bytes` must be a `bytes` object of exactly eight bytes,
+# interpreted without a sign. Addition, subtraction and multiplication
+# share the bit pattern of their signed `i64` counterparts, while
+# comparisons and division are made unsigned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[as-bytes] > u64
+  as-bytes > @
+  plus. > [] > as-number
+    as-number.
+      i64 as-bytes
+    if.
+      eq.
+        as-bytes.and 80-00-00-00-00-00-00-00
+        80-00-00-00-00-00-00-00
+      1.8446744073709552e19
+      0
+  as-bytes.xor 80-00-00-00-00-00-00-00 > flip
+  gt. > [x] > gt
+    i64 flip
+    i64 x.as-u64.flip
+  gte. > [x] > gte
+    i64 flip
+    i64 x.as-u64.flip
+  lt. > [x] > lt
+    i64 flip
+    i64 x.as-u64.flip
+  lte. > [x] > lte
+    i64 flip
+    i64 x.as-u64.flip
+  [x] > minus
+    u64 > @
+      as-bytes.
+        minus. >>
+          i64 as-bytes
+          i64 x.as-u64.as-bytes
+  [x] > plus
+    u64 > @
+      as-bytes.
+        plus. >>
+          i64 as-bytes
+          i64 x.as-u64.as-bytes
+  [x] > times
+    u64 > @
+      as-bytes.
+        times. >>
+          i64 as-bytes
+          i64 x.as-u64.as-bytes
+
+  eq. ++> can-add-one-to-one
+    00-00-00-00-00-00-00-01.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
+    00-00-00-00-00-00-00-02.as-u64
+
+  eq. ++> can-add-with-overflow
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.plus 00-00-00-00-00-00-00-01.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  gte. ++> can-be-greater-than-or-equal-to-an-equal-u64
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lt. ++> can-be-less-than-a-larger-u64
+    00-00-00-00-00-00-00-0A.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lte. ++> can-be-less-than-or-equal-to-an-equal-u64
+    00-00-00-00-00-00-00-32.as-u64
+    00-00-00-00-00-00-00-32.as-u64
+
+  lt. ++> can-be-less-than-the-maximum-when-zero
+    00-00-00-00-00-00-00-00.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> can-convert-a-small-value-to-a-number
+    00-00-00-00-00-00-00-2A.as-u64.as-number
+    42
+
+  gt. ++> can-convert-to-an-unsigned-number
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    0
+
+  eq. ++> can-equal-the-same-u64
+    00-00-00-00-00-00-00-2A.as-u64
+    00-00-00-00-00-00-00-2A.as-u64
+
+  eq. ++> can-expose-valid-bytes
+    00-00-00-00-00-00-00-2A.as-u64.as-bytes
+    00-00-00-00-00-00-00-2A
+
+  eq. ++> can-multiply
+    00-00-00-00-00-00-00-06.as-u64.times 00-00-00-00-00-00-00-07.as-u64
+    00-00-00-00-00-00-00-2A.as-u64
+
+  eq. ++> can-subtract
+    00-00-00-00-00-00-00-05.as-u64.minus 00-00-00-00-00-00-00-03.as-u64
+    00-00-00-00-00-00-00-02.as-u64
+
+  eq. ++> can-subtract-with-underflow
+    00-00-00-00-00-00-00-00.as-u64.minus 00-00-00-00-00-00-00-01.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  gt. ++> can-treat-a-high-bit-as-magnitude-when-greater
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+    00-00-00-00-00-00-00-01.as-u64
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-sixty-fourth
+    00-00-00-01-00-00-00-00.as-u64.times 00-00-00-01-00-00-00-00.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u64
+    00-00-00-00-00-00-00-00.as-u64.gte 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> cannot-be-less-than-an-equal-u64
+    00-00-00-00-00-00-00-0A.as-u64.lt 00-00-00-00-00-00-00-0A.as-u64
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.lt 00-00-00-00-00-00-00-01.as-u64

--- a/objects/u64/div.eo
+++ b/objects/u64/div.eo
@@ -1,0 +1,75 @@
+# Unsigned division of the `u64` number `n` by the `u64` number `x`. The
+# dividend is halved first, so the signed `i64` division underneath never
+# sees a negative operand, and the quotient is corrected back afterwards.
+# When `x` is zero, the caller-supplied `cant-divide` fallback is returned.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package u64
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[n x cant-divide] > div
+  if. > @
+    d.as-bytes.eq 00-00-00-00-00-00-00-00
+    cant-divide
+      "Can't divide %d by u64 zero".printf
+        * n.as-number
+    if.
+      eq.
+        d.as-bytes.and 80-00-00-00-00-00-00-00
+        80-00-00-00-00-00-00-00
+      if.
+        n.gte x.as-u64
+        u64 00-00-00-00-00-00-00-01
+        u64 00-00-00-00-00-00-00-00
+      if.
+        gte.
+          n.minus
+            times.
+              u64
+                left. >> q0
+                  as-bytes.
+                    div.
+                      i64 (n.as-bytes.right 1)
+                      i64
+                        as-bytes.
+                          x.as-u64 >> d
+                  1
+              x.as-u64
+          x.as-u64
+        plus.
+          u64 q0
+          u64 00-00-00-00-00-00-00-01
+        u64 q0
+
+  eq. ++> can-divide-a-small-value-by-a-larger-divisor
+    00-00-00-00-00-00-00-0A.as-u64.div 80-00-00-00-00-00-00-00.as-u64
+    00-00-00-00-00-00-00-00.as-u64
+
+  eq. ++> can-divide-by-a-large-divisor
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 80-00-00-00-00-00-00-00.as-u64
+    00-00-00-00-00-00-00-01.as-u64
+
+  eq. ++> can-divide-by-one
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-01.as-u64
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> can-divide-with-a-remainder
+    00-00-00-00-00-00-00-2A.as-u64.div 00-00-00-00-00-00-00-05.as-u64
+    00-00-00-00-00-00-00-08.as-u64
+
+  eq. ++> can-divide-without-a-sign
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.div 00-00-00-00-00-00-00-02.as-u64
+    7F-FF-FF-FF-FF-FF-FF-FF.as-u64
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    00-00-00-00-00-00-00-02.as-u64.div
+      00-00-00-00-00-00-00-00.as-u64
+      "recovered" > [message]
+
+  div. --> stops-on-division-by-zero
+    00-00-00-00-00-00-00-02.as-u64
+    00-00-00-00-00-00-00-00.as-u64

--- a/objects/u8.eo
+++ b/objects/u8.eo
@@ -1,0 +1,131 @@
+# Unsigned 8-bit integer.
+# Here `as-bytes` must be a `bytes` object of exactly one byte,
+# interpreted without a sign.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[as-bytes] > u8
+  as-bytes > @
+  i16 > [] > as-i16
+    00-.concat as-bytes
+  as-i16.as-number > as-number
+  [x cant-divide] > div
+    if. > @
+      eq.
+        x.as-u8 >> other
+        00-
+      cant-divide
+        "Can't divide %d by u8 zero".printf
+          * as-number
+      u8
+        slice.
+          as-bytes.
+            as-i16.div other.as-i16
+          1
+          1
+  as-i16.gt x.as-u8.as-i16 > [x] > gt
+  as-i16.gte x.as-u8.as-i16 > [x] > gte
+  as-i16.lt x.as-u8.as-i16 > [x] > lt
+  as-i16.lte x.as-u8.as-i16 > [x] > lte
+  u8 > [x] > minus
+    slice.
+      as-bytes.
+        as-i16.minus x.as-u8.as-i16
+      1
+      1
+  u8 > [x] > plus
+    slice.
+      as-bytes.
+        as-i16.plus x.as-u8.as-i16
+      1
+      1
+  u8 > [x] > times
+    slice.
+      as-bytes.
+        as-i16.times x.as-u8.as-i16
+      1
+      1
+
+  eq. ++> can-add-one-to-one
+    01-.as-u8.plus 01-.as-u8
+    02-.as-u8
+
+  eq. ++> can-add-with-overflow
+    FF-.as-u8.plus 01-.as-u8
+    00-.as-u8
+
+  32-.as-u8.gte 32-.as-u8 ++> can-be-greater-than-or-equal-to-an-equal-u8
+
+  0A-.as-u8.lt 32-.as-u8 ++> can-be-less-than-a-larger-u8
+
+  32-.as-u8.lte 32-.as-u8 ++> can-be-less-than-or-equal-to-an-equal-u8
+
+  00-.as-u8.lt FF-.as-u8 ++> can-be-less-than-the-maximum-when-zero
+
+  FF-.as-u8.as-number.eq 255 ++> can-convert-to-an-unsigned-number
+
+  eq. ++> can-divide-by-one
+    FF-.as-u8.div 01-.as-u8
+    FF-.as-u8
+
+  eq. ++> can-divide-without-a-sign
+    C8-.as-u8.div 03-.as-u8
+    42-.as-u8
+
+  2A-.as-u8.eq 2A-.as-u8 ++> can-equal-the-same-u8
+
+  2A-.as-u8.as-bytes.eq 2A- ++> can-expose-valid-bytes
+
+  eq. ++> can-multiply
+    06-.as-u8.times 07-.as-u8
+    2A-.as-u8
+
+  eq. ++> can-read-the-maximum-byte-as-unsigned
+    255.as-i64.as-i32.as-i16
+    FF-.as-u8.as-i16
+
+  eq. ++> can-subtract
+    05-.as-u8.minus 03-.as-u8
+    02-.as-u8
+
+  eq. ++> can-subtract-with-underflow
+    00-.as-u8.minus 01-.as-u8
+    FF-.as-u8
+
+  FF-.as-u8.gt 01-.as-u8 ++> can-treat-a-high-bit-as-magnitude-when-greater
+
+  FF-.as-u8.as-i16.as-bytes.eq 00-FF ++> can-widen-to-i16-with-a-zero-prefix
+
+  eq. ++> can-wrap-a-large-product
+    FF-.as-u8.times FF-.as-u8
+    01-.as-u8
+
+  eq. ++> can-wrap-a-product-modulo-two-to-the-eighth
+    10-.as-u8.times 10-.as-u8
+    00-.as-u8
+
+  not. ++> cannot-be-greater-than-or-equal-to-a-larger-u8
+    00-.as-u8.gte 0A-.as-u8
+
+  not. ++> cannot-be-less-than-an-equal-u8
+    0A-.as-u8.lt 0A-.as-u8
+
+  not. ++> cannot-be-less-than-one-with-a-high-bit
+    FF-.as-u8.lt 01-.as-u8
+
+  not. ++> cannot-equal-a-different-u8
+    2A-.as-u8.eq 2B-.as-u8
+
+  eq. ++> rejects-division-by-zero
+    "recovered"
+    02-.as-u8.div
+      00-.as-u8
+      "recovered" > [message]
+
+  02-.as-u8.div 00-.as-u8 --> stops-on-division-by-zero

--- a/objects/uri.eo
+++ b/objects/uri.eo
@@ -1,0 +1,228 @@
+# Parses an RFC 3986 generic URI `text` and exposes its components as
+# read-only attributes: `scheme`, `authority` (together with `userinfo`,
+# `host` and `port` parsed out of it), `path`, `query` and `fragment`.
+#
+# Usage, without an authority:
+# ```
+# uri "pgsql:localhost:899" > x
+# x.scheme > s   # pgsql
+# x.path > p     # localhost:899
+# ```
+# With a "//" authority:
+# ```
+# uri "pgsql://localhost:899" > x
+# x.host > h    # localhost
+# x.port > p    # 899
+# ```
+#
+# The object is immutable: it only reads parts of `text` and has no mutators.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint redundant-object
++unlint mandatory-package
+
+[text] > uri
+  text > @
+  if. > authority
+    string.starts-with >> has-authority
+      hier-part
+      "//"
+    if.
+      not. >> has-authority-path
+        eq.
+          string.index-of after-slashes "/" >> authority-path-idx
+          -1
+      slice.
+        has-authority.if >> after-slashes
+          slice.
+            has-query.if >> hier-part
+              before-fragment.slice 0 question-idx
+              before-fragment
+            2
+            hier-part.length.minus
+              number 2
+          ""
+        0
+        authority-path-idx
+      after-slashes
+    ""
+  if. > fragment
+    not. >> has-fragment
+      hash-idx.eq -1
+    slice.
+      text.slice >> rest
+        plus.
+          string.index-of text ":" >> scheme-colon
+          1
+        text.length.minus
+          number
+            scheme-colon.plus 1
+      plus.
+        string.index-of rest "#" >> hash-idx
+        1
+      rest.length.minus
+        number
+          hash-idx.plus 1
+    ""
+  if. > host
+    not. >> has-port
+      port-colon-idx.eq -1
+    slice.
+      has-userinfo.if >> host-port
+        authority.slice
+          plus.
+            string.index-of authority "@" >> userinfo-at-idx
+            1
+          authority.length.minus
+            number
+              userinfo-at-idx.plus 1
+        authority
+      0
+      port-colon-idx
+    host-port
+  has-authority.if > path
+    has-authority-path.if
+      after-slashes.slice
+        authority-path-idx
+        after-slashes.length.minus
+          number authority-path-idx
+      ""
+    hier-part
+  has-port.if > port
+    host-port.slice
+      plus.
+        if. >> port-colon-idx
+          string.starts-with host-port "[" >>
+          if.
+            eq.
+              string.index-of >> rel-colon
+                host-port.slice
+                  bracket-start
+                  host-port.length.minus
+                    number bracket-start
+                ":"
+              -1
+            -1
+            rel-colon.plus
+              plus. >> bracket-start
+                string.index-of host-port "]" >>
+                1
+          string.index-of host-port ":"
+        1
+      host-port.length.minus
+        number
+          port-colon-idx.plus 1
+    ""
+  if. > query
+    not. >> has-query
+      question-idx.eq -1
+    slice.
+      has-fragment.if >> before-fragment
+        rest.slice 0 hash-idx
+        rest
+      plus.
+        string.index-of before-fragment "?" >> question-idx
+        1
+      before-fragment.length.minus
+        number
+          question-idx.plus 1
+    ""
+  text.slice > scheme
+    0
+    scheme-colon
+  if. > userinfo
+    not. >> has-userinfo
+      userinfo-at-idx.eq -1
+    authority.slice
+      0
+      userinfo-at-idx
+    ""
+
+  eq. ++> can-parse-a-bracketed-ipv6-host-with-a-port
+    host.
+      uri "http://[::1]:8080/p"
+    "[::1]"
+
+  eq. ++> can-parse-a-bracketed-ipv6-host-without-a-port
+    host.
+      uri "http://[2001:db8::1]/p"
+    "[2001:db8::1]"
+
+  eq. ++> can-parse-a-fragment-without-a-leading-hash
+    fragment.
+      uri "http://host/some/path?x=1#top"
+    "top"
+
+  eq. ++> can-parse-a-host-alongside-userinfo
+    host.
+      uri "http://user:pass@host:80/some/path"
+    "host"
+
+  eq. ++> can-parse-a-path-alongside-a-userinfo-authority
+    path.
+      uri "http://user:pass@host:80/some/path"
+    "/some/path"
+
+  eq. ++> can-parse-a-port-alongside-userinfo
+    port.
+      uri "http://user:pass@host:80/some/path"
+    "80"
+
+  eq. ++> can-parse-a-query-without-a-leading-question-mark
+    query.
+      uri "http://host/some/path?x=1#top"
+    "x=1"
+
+  eq. ++> can-parse-the-empty-host-of-a-triple-slash-uri
+    host.
+      uri "file:///etc/passwd"
+    ""
+
+  eq. ++> can-parse-the-empty-path-of-an-authority-only-uri
+    path.
+      uri "pgsql://localhost:899"
+    ""
+
+  eq. ++> can-parse-the-host-of-an-authority-with-a-port
+    host.
+      uri "pgsql://localhost:899"
+    "localhost"
+
+  eq. ++> can-parse-the-path-of-a-bare-scheme-uri
+    path.
+      uri "pgsql:localhost:899"
+    "localhost:899"
+
+  eq. ++> can-parse-the-path-of-a-triple-slash-uri
+    path.
+      uri "file:///etc/passwd"
+    "/etc/passwd"
+
+  eq. ++> can-parse-the-port-of-a-bracketed-ipv6-host
+    port.
+      uri "http://[::1]:8080/p"
+    "8080"
+
+  eq. ++> can-parse-the-port-of-an-authority
+    port.
+      uri "pgsql://localhost:899"
+    "899"
+
+  eq. ++> can-parse-the-scheme-of-a-bare-scheme-uri
+    scheme.
+      uri "pgsql:localhost:899"
+    "pgsql"
+
+  eq. ++> can-parse-the-scheme-of-a-triple-slash-uri
+    scheme.
+      uri "file:///etc/passwd"
+    "file"
+
+  eq. ++> can-parse-the-userinfo-of-an-authority
+    userinfo.
+      uri "http://user:pass@host:80/some/path"
+    "user:pass"

--- a/objects/while.eo
+++ b/objects/while.eo
@@ -1,18 +1,10 @@
-+architect yegor256@gmail.com
-+home https://github.com/objectionary/eo
-+version 0.61.3
-+spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
-+spdx SPDX-License-Identifier: MIT
-+unlint mandatory-package
-
-# The `while` object is very similar to a loop with a pre-condition.
+# Loop `while` with a pre-condition.
 # Here's how you can use it:
 # ```
 # while > last
 #   i.lt 5 > [i]
 #   [i]
-#     Q.tt.sprintf > @
-#       "Iteration %d\n"
+#     "Iteration %d\n".printf > @
 #       * i
 # ```
 #
@@ -29,29 +21,34 @@
 # Only the first three strings are dataized for side effects while the last one
 # is returned as the result value assigned to the `last` object.
 # The `while` loop example produces identical behavior.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
+
 [condition body] > while
   if. > @
-    (condition 0).as-bool
-    loop 0
+    as-bool.
+      condition 0
+    [index] >> loop
+      if. > @
+        as-bool.
+          condition
+            index.plus 1
+        seq *
+          current
+          loop
+            index.plus 1
+        current
+      body index > current
+    | 0
     false
 
-  # Recursive loop.
-  #
-  # Note: This object is intended for internal use only. Please do not use
-  # this object programmatically outside of the `while` object.
-  [index] > loop
-    if. > @
-      (condition (index.plus 1)).as-bool
-      seq *
-        current
-        loop (index.plus 1)
-      current
-    body index > current
-
-  # Tests that while loop dataizes only the first cycle when condition becomes false.
-  [] +> tests-while-dataizes-only-first-cycle
-    eq. > @
-      0
+  ++> can-dataize-only-the-first-cycle
+    0.eq > @
       malloc.for
         42
         [m]
@@ -59,58 +56,36 @@
             i.eq 0 > [i]
             m.put i > [i] >>
 
-  # Tests that while loop returns false when condition is initially false.
-  [] +> tests-simple-while-with-false-first
-    not. > @
-      while
-        false > [i]
-        true > [i]
+  ++> can-iterate-a-tuple-with-an-external-iterator
+    data.eq array.length > @
+    * > array
+      1
+      1
+      1
+      1
+    malloc.for > data
+      0
+      [acc] >>
+        malloc.for > @
+          0
+          [iter] >>
+            while > @
+              max.gt iter > [i] >>
+              seq * > [i] >>
+                acc.put
+                  acc.as-number.plus
+                    array.at iter
+                iter.put
+                  iter.as-number.plus 1
+    array.length.plus -1 > max
 
-  # Tests that while loop works with boolean expressions using malloc memory.
-  [] +> tests-simple-bool-expression-via-malloc-in-while
-    eq. > @
-      malloc.for
-        true
-        [m]
-          while > @
-            m > [i] >>
-            m.put false > [i] >>
-      false
-
-  # Tests that while loop returns the last dataized object when loop completes.
-  [] +> tests-last-while-dataization-object
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            2.gt m > [i] >>
-            m.put (m.as-number.plus 1) > [i] >>
-      3
-
-  # Tests that while loop returns false when condition evaluates to false initially.
-  [] +> tests-last-while-dataization-object-with-false-condition
-    not. > @
-      while
-        1.gt 2 > [i]
-        true > [i]
-
-  # Tests that while loop performs simple iteration and updates counter correctly.
-  [] +> tests-while-simple-iteration
-    eq. > @
-      malloc.for
-        0
-        [m]
-          while > @
-            i.lt 10 > [i]
-            m.put i > [i] >>
-      9
-
-  # Tests that while loop can iterate over tuple elements using internal iterator.
-  [] +> tests-iterating-tuple-with-while-using-internal-iterator
-    data.eq arr.length > @
-    * 1 1 1 1 > arr
-    arr.length.plus -1 > max
+  ++> can-iterate-a-tuple-with-an-internal-iterator
+    data.eq array.length > @
+    * > array
+      1
+      1
+      1
+      1
     malloc.for > data
       0
       [acc] >>
@@ -121,96 +96,102 @@
               max.eq 0
               acc.put
                 acc.as-number.plus
-                  arr.at 0
+                  array.at 0
               while
                 max.gt iter > [i] >>
-                [i] >>
-                  seq > @
-                    *
-                      acc.put
-                        acc.as-number.plus
-                          arr.at i
-                      iter.put
-                        iter.as-number.plus 1
+                seq * > [i] >>
+                  acc.put
+                    acc.as-number.plus (array.at i)
+                  iter.put
+                    iter.as-number.plus 1
+    array.length.plus -1 > max
 
-  # Tests that while loop can iterate over tuple elements using external iterator.
-  [] +> tests-iterating-tuple-with-while-using-external-iterator
-    data.eq arr.length > @
-    * 1 1 1 1 > arr
-    arr.length.plus -1 > max
+  ++> can-iterate-a-tuple-without-a-body-many-times
+    data.eq array.length > @
+    * > array
+      1
+      1
+      1
     malloc.for > data
       0
       [acc] >>
         malloc.for > @
           0
           [iter] >>
-            while > @
-              max.gt iter > [i] >>
-              [i] >>
-                seq > @
-                  *
+            seq * > @
+              while
+                if. > [i] >>
+                  max.gt iter
+                  seq *
                     acc.put
-                      acc.as-number.plus
-                        arr.at iter
-                    iter.put
-                      iter.as-number.plus 1
+                      acc.as-number.plus (array.at iter.as-number)
+                    iter.put (iter.as-number.plus 1)
+                    true
+                  false
+                true > [i]
+              acc
+    array.length > max
 
-  # Tests that while loop can iterate over multiple tuple elements without explicit body.
-  [] +> tests-iterating-tuple-with-while-without-body-multiple
-    data.eq arr.length > @
-    * 1 1 1 > arr
-    arr.length > max
+  ++> can-iterate-a-tuple-without-a-body-once
+    data.eq array.length > @
+    * 1 > array
     malloc.for > data
       0
       [acc] >>
         malloc.for > @
           0
           [iter] >>
-            seq > @
-              *
-                while
-                  [i] >>
-                    if. > @
-                      max.gt iter
-                      seq
-                        *
-                          acc.put
-                            acc.as-number.plus
-                              arr.at
-                                iter.as-number
-                          iter.put
-                            iter.as-number.plus 1
-                          true
-                      false
-                  true > [i]
-                acc
+            seq * > @
+              while
+                if. > [i] >>
+                  max.gt iter
+                  seq *
+                    acc.put
+                      acc.as-number.plus (array.at iter.as-number)
+                    iter.put (iter.as-number.plus 1)
+                    true
+                  false
+                true > [i]
+              acc
+    array.length > max
 
-  # Tests that while loop can iterate over single tuple element without explicit body.
-  [] +> tests-iterating-tuple-with-while-without-body-single
-    data.eq arr.length > @
-    * 1 > arr
-    arr.length > max
-    malloc.for > data
-      0
-      [acc] >>
-        malloc.for > @
-          0
-          [iter] >>
-            seq > @
-              *
-                while
-                  [i] >>
-                    if. > @
-                      max.gt iter
-                      seq
-                        *
-                          acc.put
-                            acc.as-number.plus
-                              arr.at
-                                iter.as-number
-                          iter.put
-                            iter.as-number.plus 1
-                          true
-                      false
-                  true > [i]
-                acc
+  ++> can-loop-on-a-bool-expression-kept-in-malloc
+    eq. > @
+      malloc.for
+        true
+        [m]
+          while > @
+            m > [i] >>
+            m.put false > [i] >>
+      false
+
+  ++> can-loop-over-a-simple-iteration
+    eq. > @
+      malloc.for
+        0
+        [m]
+          while > @
+            i.lt 10 > [i]
+            m.put i > [i] >>
+      9
+
+  not. ++> can-loop-when-the-condition-is-false-first
+    while
+      false > [i]
+      true > [i]
+
+  ++> can-return-the-last-dataized-object
+    eq. > @
+      malloc.for
+        0
+        [m]
+          while > @
+            2.gt m > [i] >>
+            m.put > [i] >>
+              m.as-number.plus 1
+      3
+
+  not. ++> can-return-the-last-dataized-object-with-a-false-condition
+    while
+      1.gt 2 > [i]
+      true > [i]

--- a/objects/win32.eo
+++ b/objects/win32.eo
@@ -1,0 +1,61 @@
+# Makes a windows syscall by `name`.
+#
+# The non-socket operations (file, console, process, environment and clock) go
+# through the Microsoft C runtime (msvcrt), which exposes POSIX-compatible
+# functions returning integer file descriptors, so the win32 objects thread them
+# through EO exactly like the posix ones. Sockets stay on Winsock (ws2_32), since
+# the C runtime has no BSD sockets. You can look the functions up in the CRT
+# reference (https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference)
+# and the Winsock reference (https://learn.microsoft.com/en-us/windows/win32/api/winsock2).
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++rt jvm org.eolang:eo-runtime:0.62.0
++rt node eo2js-runtime:0.0.0
++version 0.62.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
++unlint mandatory-package
++unlint redundant-object
+
+[name args] > win32
+  [] > @ /Q.win32.return
+  8 > append
+  256 > creat
+  -1 > failure
+  2 > inet
+  -1 > invalid
+  384 > mode
+  -1 > none
+  32768 > rdonly
+  32770 > rdwr
+  [code output] > return
+    output > @
+    return > called
+      code
+      output
+  [family port address] > sockaddr-in
+    00-00-00-00-00-00-00-00 > padding
+    plus. > size
+      plus.
+        family.size.plus port.size
+        address.size
+      padding.size
+  [mode size] > stat64
+  2 > stderr
+  0 > stdin
+  1 > stdout
+  1 > stream
+  6 > tcp
+  [time millitm] > timeb
+  512 > trunc
+  02-02 > version
+  32769 > wronly
+
+  os.is-windows.not.or ++> can-return-an-inet-address-for-localhost
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "127.0.0.1"
+      16777343


### PR DESCRIPTION
A new release `eo-0.62.0` of the EO-to-Java compiler has been published on Maven Central. Don't forget to make a release here, asking `@rultor` about it.